### PR TITLE
Remove the short option for threaded

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -39,7 +39,7 @@ pub struct Args {
   pub fresh_merge: Vec<PathBuf>,
 
   /// Use threads when possible
-  #[arg(long, short)]
+  #[arg(long)]
   pub threaded: Option<bool>,
 
   /// the destination for `mergenew`


### PR DESCRIPTION
This fixes a collision between `threads` and `threaded`, which both want to use `-t` for the short option:

```
Command bigtent: Short option names must be unique for each argument, but '-t' is in use by both 'threads' and 'threaded'
```

### 💻 Description of Change(s) (w/ context)
What did you change, and what additional context do reviewers need?

### 🧠 Rationale Behind Change(s)
Why were these changes made? What tradeoffs were considered?

### 📝 Test Plan
Beyond unit tests, how did you make sure this code is ready for production?

### 📜 Documentation
What documentation did you add or update? 
Was the documentation appropriate for the scope of this change?

### 💣 Quality Control
(All items must be checked before a PR is merged)
Did you…
- [ ] Mention an issue number in the PR title?
- [ ] Update the version # in the build file?
- [ ] Create new and/or update relevant existing tests?
- [ ] Create or update relevant documentation and/or diagrams?
- [ ] Comment your code?
- [ ] Fix any stray verbose logging (removing, or moving to debug / trace level)?

### Before Merging…
- Make sure the Quality Control boxes are all ticked
- Make sure any open comments or conversations on the PR are resolved
