### PR TITLE
Improve errors and documentation of config parameters (#18)

### DIFF
--- a/info/config.md
+++ b/info/config.md
@@ -1,8 +1,10 @@
 # Configuration
 
-The `config.toml` file is a sectionless TOML file.
+The `config.toml` file is a TOML file. The keys are not namespaced into
+tables.
 
 Keys:
 
-- `root_dir`, a string path to the root of the data storage
-- `cluster_path`, a string path to ????
+- `root_dir`, a string path to the root of the data storage.
+- `cluster_path`, a string path to the cluster directory (parent of the
+  `.grc` file) within the root data directory.

--- a/info/config.md
+++ b/info/config.md
@@ -1,0 +1,8 @@
+# Configuration
+
+The `config.toml` file is a sectionless TOML file.
+
+Keys:
+
+- `root_dir`, a string path to the root of the data storage
+- `cluster_path`, a string path to ????

--- a/src/rodeo.rs
+++ b/src/rodeo.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Result, Context};
 use arc_swap::ArcSwap;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -177,7 +177,7 @@ where
     };
 
     // open and get info from the data file
-    let mut cluster_file = File::open(file_path.clone())?;
+    let mut cluster_file = File::open(file_path.clone()).with_context(|| format!("opening cluster {:?}", file_path))?;
 
     let sha_u64 = byte_slice_to_u63(&sha256_for_reader(&mut cluster_file)?)?;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,5 @@
 use crate::{index_file::ItemOffset, rodeo_server::MD5Hash};
-use anyhow::{bail, Result};
+use anyhow::{bail, Result, Context};
 #[cfg(not(test))]
 use log::info;
 use serde::{de::DeserializeOwned, Serialize};
@@ -165,7 +165,7 @@ fn test_sha256() {
 pub fn is_child_dir(root: &PathBuf, potential_child: &PathBuf) -> Result<bool> {
   let full_root = root.canonicalize()?;
 
-  let full_kid = potential_child.canonicalize()?;
+  let full_kid = potential_child.canonicalize().with_context(|| format!("child directory {:?}", potential_child))?;
 
   let mut kid_parts = HashSet::new();
   for i in full_kid.iter() {


### PR DESCRIPTION
### 💻 Description of Change(s) (w/ context)

This shows what was being accessed when it fails

### 🧠 Rationale Behind Change(s)

Setting up `bigtent`, I made a mistake in the config file and had to use the backtrace to figure out what the error message was even about.

### 📝 Test Plan
Hand-tested the failure case.

### 📜 Documentation
Documented the config file format.

### 💣 Quality Control
(All items must be checked before a PR is merged)
Did you…
- [X] Mention an issue number in the PR title?
- [x] Update the version # in the build file?
- [X] Create new and/or update relevant existing tests?
- [X] Create or update relevant documentation and/or diagrams?
- [X] Comment your code?
- [X] Fix any stray verbose logging (removing, or moving to debug / trace level)?

### Before Merging…
- Make sure the Quality Control boxes are all ticked
- Make sure any open comments or conversations on the PR are resolved
