### PR TITLE
An initial openapi spec for the bigtent API

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -35,7 +35,8 @@ paths:
                   merged_from:
                     type: array
                   metadata:
-                    type: 'null'
+                    type: 'object'
+                    properties:
                   reference:
                     type: array
                     items:
@@ -82,60 +83,6 @@ paths:
                   metadata:
                     type: object
                     properties:
-                      extra:
-                        type: object
-                        properties:
-                          artifact_id:
-                            type: array
-                            items:
-                              type: string
-                          group_id:
-                            type: array
-                            items:
-                              type: string
-                          package_protocol:
-                            type: array
-                            items:
-                              type: string
-                          purl:
-                            type: array
-                            items:
-                              type: string
-                          type:
-                            type: array
-                            items:
-                              type: string
-                          version:
-                            type: array
-                            items:
-                              type: string
-                        required:
-                        - artifact_id
-                        - group_id
-                        - package_protocol
-                        - purl
-                        - type
-                        - version
-                      file_names:
-                        type: array
-                        items:
-                          type: string
-                      file_size:
-                        type: integer
-                      file_sub_type:
-                        type: array
-                        items:
-                          type: string
-                      file_type:
-                        type: array
-                        items:
-                          type: string
-                    required:
-                    - extra
-                    - file_names
-                    - file_size
-                    - file_sub_type
-                    - file_type
                   reference:
                     type: array
                     items:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,152 @@
+openapi: 3.1.0
+info:
+  title: Spice Labs BigTent
+  version: 0.1.0
+  description: the BigTent API
+paths:
+  /{alias}:
+    get:
+      tags:
+      - package
+      operationId: dereferenceAlias
+      summary: dereference an asset by alias to get its root gitoid 
+      description: Get an asset by its alias
+      parameters:
+      - name: alias
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  connections:
+                    type: array
+                    items:
+                      type: array
+                      items:
+                        type: string
+                  identifier:
+                    type: string
+                  merged_from:
+                    type: array
+                  metadata:
+                    type: 'null'
+                  reference:
+                    type: array
+                    items:
+                      type: integer
+                required:
+                - connections
+                - identifier
+                - merged_from
+                - metadata
+                - reference
+          description: ''
+          headers: {}
+      security: []
+  /aa/{gitoid}:
+    get:
+      tags: 
+      - package
+      operationId: get
+      summary: Get by innate gitoid
+      description: Get an asset by its innate gitoid
+      parameters:
+      - name: gitoid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  connections:
+                    type: array
+                    items:
+                      type: array
+                      items:
+                        type: string
+                  identifier:
+                    type: string
+                  merged_from:
+                    type: array
+                  metadata:
+                    type: object
+                    properties:
+                      extra:
+                        type: object
+                        properties:
+                          artifact_id:
+                            type: array
+                            items:
+                              type: string
+                          group_id:
+                            type: array
+                            items:
+                              type: string
+                          package_protocol:
+                            type: array
+                            items:
+                              type: string
+                          purl:
+                            type: array
+                            items:
+                              type: string
+                          type:
+                            type: array
+                            items:
+                              type: string
+                          version:
+                            type: array
+                            items:
+                              type: string
+                        required:
+                        - artifact_id
+                        - group_id
+                        - package_protocol
+                        - purl
+                        - type
+                        - version
+                      file_names:
+                        type: array
+                        items:
+                          type: string
+                      file_size:
+                        type: integer
+                      file_sub_type:
+                        type: array
+                        items:
+                          type: string
+                      file_type:
+                        type: array
+                        items:
+                          type: string
+                    required:
+                    - extra
+                    - file_names
+                    - file_size
+                    - file_sub_type
+                    - file_type
+                  reference:
+                    type: array
+                    items:
+                      type: integer
+                required:
+                - connections
+                - identifier
+                - merged_from
+                - metadata
+                - reference
+          description: ''
+          headers: {}
+      security: []
+components: {}


### PR DESCRIPTION
This gives a machine readable description of the two available endpoints (to be refined particularly for the shape of the response, but good enough for now) that lets me use [requests_openapi](https://github.com/wy-z/requests-openapi) to query the API from a notebook