### PR TITLE
Made Big Tent generic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,7 +127,7 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "bigtent"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bigtent"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["David Pollak <feeder.of.the.bears@gmail.com>"]
 rust-version = "1.81.0"

--- a/src/cluster_writer.rs
+++ b/src/cluster_writer.rs
@@ -18,7 +18,7 @@ use crate::{
   rodeo::{ClusterFileEnvelope, ClusterFileMagicNumber, DataFileMagicNumber, IndexFileMagicNumber},
   rodeo_server::MD5Hash,
   sha_writer::ShaWriter,
-  structs::{Item, MetaData},
+  structs::Item,
   util::{
     byte_slice_to_u63, md5hash_str, path_plus_timed, sha256_for_slice, write_envelope, write_int,
     write_long, write_short_signed,
@@ -93,9 +93,7 @@ impl ClusterWriter {
     self.previous_position
   }
 
-  pub fn write_item<MDT>(&mut self, mut item: Item<MDT>) -> Result<()>
-  where
-    for<'de2> MDT: MetaData<'de2>,
+  pub fn write_item(&mut self, mut item: Item) -> Result<()>
   {
     use std::io::Write;
     let the_hash = md5hash_str(&item.identifier);

--- a/src/data_file.rs
+++ b/src/data_file.rs
@@ -1,6 +1,6 @@
 use crate::{
   rodeo::{DataFileMagicNumber, GoatRodeoCluster},
-  structs::{Item, MetaData},
+  structs::Item,
   util::{read_cbor, read_len_and_cbor, read_u32},
 };
 use anyhow::{anyhow, bail, Result};
@@ -9,7 +9,6 @@ use std::{
   collections::{BTreeMap, BTreeSet},
   fs::File,
   io::{BufReader, Seek},
-  marker::PhantomData,
   path::PathBuf,
   sync::{Arc, Mutex},
 };
@@ -25,24 +24,15 @@ pub struct DataFileEnvelope {
 }
 
 #[derive(Debug, Clone)]
-pub struct DataFile<MDT>
-where
-  for<'de2> MDT: MetaData<'de2>,
-{
+pub struct DataFile {
   pub envelope: DataFileEnvelope,
   pub file: Arc<Mutex<BufReader<File>>>,
   pub data_offset: u64,
-  // in order to generate a specialized struct with the `MDT` type,
-  // the struct must contain the type as an element. See https://doc.rust-lang.org/rust-by-example/generics/phantom.html
-  _phantom: PhantomData<MDT>,
 }
 
-impl<MDT> DataFile<MDT>
-where
-  for<'de2> MDT: MetaData<'de2>,
-{
-  pub fn new(dir: &PathBuf, hash: u64) -> Result<DataFile<MDT>> {
-    let mut data_file = GoatRodeoCluster::<MDT>::find_file(dir, hash, "grd")?;
+impl DataFile {
+  pub fn new(dir: &PathBuf, hash: u64) -> Result<DataFile> {
+    let mut data_file = GoatRodeoCluster::find_file(dir, hash, "grd")?;
     let dfp: &mut File = &mut data_file;
     let magic = read_u32(dfp)?;
     if magic != DataFileMagicNumber {
@@ -62,7 +52,6 @@ where
       envelope: env,
       file: Arc::new(Mutex::new(BufReader::with_capacity(4096, data_file))),
       data_offset: cur_pos,
-      _phantom: PhantomData::default(),
     })
   }
 
@@ -78,12 +67,12 @@ where
     Ok(())
   }
 
-  pub fn read_item_at(&self, pos: u64) -> Result<Item<MDT>> {
+  pub fn read_item_at(&self, pos: u64) -> Result<Item> {
     let mut my_file = self
       .file
       .lock()
       .map_err(|e| anyhow!("Failed to lock {:?}", e))?;
-    DataFile::<MDT>::seek_to(&mut my_file, pos)?;
+    DataFile::seek_to(&mut my_file, pos)?;
     let my_reader: &mut BufReader<File> = &mut my_file;
     let item_len = read_u32(my_reader)?;
     let item = read_cbor(&mut *my_file, item_len as usize)?;

--- a/src/live_merge.rs
+++ b/src/live_merge.rs
@@ -7,7 +7,7 @@ use crate::{
   index_file::{IndexLoc, ItemOffset},
   mod_share::{update_top, ClusterPos},
   rodeo::GoatRodeoCluster,
-  structs::{Item, ItemMergeResult, MetaData},
+  structs::{Item, ItemMergeResult},
   util::path_plus_timed,
 };
 use anyhow::{bail, Result};
@@ -16,11 +16,9 @@ use im::OrdMap;
 use std::println as info;
 use thousands::Separable;
 
-pub fn perform_merge<MDT>(clusters: Vec<GoatRodeoCluster<MDT>>) -> Result<GoatRodeoCluster<MDT>>
-where
-  for<'de2> MDT: MetaData<'de2>,
+pub fn perform_merge(clusters: Vec<GoatRodeoCluster>) -> Result<GoatRodeoCluster>
 {
-  let clusters: Vec<GoatRodeoCluster<MDT>> = clusters
+  let clusters: Vec<GoatRodeoCluster> = clusters
     .into_iter()
     .filter(|c| c.cluster_file_hash != 0)
     .collect();
@@ -244,9 +242,7 @@ fn test_live_merge() {
   }
 }
 
-pub fn persist_synthetic<MDT>(cluster: GoatRodeoCluster<MDT>) -> Result<GoatRodeoCluster<MDT>>
-where
-  for<'de2> MDT: MetaData<'de2>,
+pub fn persist_synthetic(cluster: GoatRodeoCluster) -> Result<GoatRodeoCluster>
 {
   // if it's not synthetic, just return it
   if !cluster.synthetic {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,6 @@ use bigtent::{
   rodeo::GoatRodeoCluster,
   rodeo_server::RodeoServer,
   server::run_web_server,
-  structs::{ItemMetaData, MetaData},
 };
 use clap::{CommandFactory, Parser};
 use env_logger::Env;
@@ -73,9 +72,7 @@ fn run_full_server(args: Args) -> Result<()> {
   Ok(())
 }
 
-fn run_merge<MDT>(paths: Vec<PathBuf>, args: Args) -> Result<()>
-where
-  for<'de2> MDT: MetaData<'de2> + 'static,
+fn run_merge(paths: Vec<PathBuf>, args: Args) -> Result<()>
 {
   for p in &paths {
     if !p.exists() || !p.is_dir() {
@@ -90,7 +87,7 @@ where
   let start = Instant::now();
 
   info!("Loading clusters...");
-  let mut clusters: Vec<GoatRodeoCluster<MDT>> = vec![];
+  let mut clusters: Vec<GoatRodeoCluster> = vec![];
   for p in &paths {
     for b in GoatRodeoCluster::cluster_files_in_dir(p.clone())? {
       clusters.push(b);
@@ -135,7 +132,7 @@ fn main() -> Result<()> {
     // normally there'd be a generic here, but because this function is `main`, it's necessary
     // to specify the concrete type (in this case `ItemMetaData`) rather than the generic
     // type
-    (None, None, v) if v.len() > 0 => run_merge::<ItemMetaData>(v.clone(), args)?,
+    (None, None, v) if v.len() > 0 => run_merge(v.clone(), args)?,
     _ => {
       Args::command().print_help()?;
     }

--- a/src/merger.rs
+++ b/src/merger.rs
@@ -19,19 +19,17 @@ use crate::{
   mod_share::{update_top, ClusterPos},
   rodeo::GoatRodeoCluster,
   rodeo_server::MD5Hash,
-  structs::{EdgeType, Item, MetaData},
+  structs::{EdgeType, Item},
   util::NiceDurationDisplay,
 };
 use anyhow::Result;
 use thousands::Separable;
 
-pub fn merge_fresh<PB: Into<PathBuf>, MDT>(
-  clusters: Vec<GoatRodeoCluster<MDT>>,
+pub fn merge_fresh<PB: Into<PathBuf>>(
+  clusters: Vec<GoatRodeoCluster>,
   use_threads: bool,
   dest_directory: PB,
 ) -> Result<()>
-where
-  for<'de2> MDT: MetaData<'de2> + 'static,
 {
   let start = Instant::now();
   let dest: PathBuf = dest_directory.into();
@@ -135,14 +133,12 @@ where
     let (next, opt_min) = top.without_min();
     top = opt_min;
 
-    fn get_item_and_pos<MDT>(
+    fn get_item_and_pos(
       hash: MD5Hash,
       which: usize,
-      index_holder: &mut Vec<ClusterPos<Option<Receiver<(Item<MDT>, usize)>>>>,
-      clusters: &Vec<GoatRodeoCluster<MDT>>,
-    ) -> Result<(Item<MDT>, usize)>
-    where
-      for<'de2> MDT: MetaData<'de2>,
+      index_holder: &mut Vec<ClusterPos<Option<Receiver<(Item, usize)>>>>,
+      clusters: &Vec<GoatRodeoCluster>,
+    ) -> Result<(Item, usize)>
     {
       match &index_holder[which].thing {
         Some(rx) => rx.recv().map_err(|e| e.into()),

--- a/src/rodeo_server.rs
+++ b/src/rodeo_server.rs
@@ -5,7 +5,6 @@ use flume::{Receiver, Sender};
 use log::{error, info};
 use pipe::PipeWriter;
 use scopeguard::defer;
-use serde_cbor::Value;
 use std::{
   collections::HashSet,
   io::{BufWriter, Write},
@@ -23,58 +22,55 @@ use crate::{
   config::Args,
   index_file::{IndexLoc, ItemOffset},
   rodeo::GoatRodeoCluster,
-  structs::{EdgeType, Item, MetaData},
+  structs::Item,
   util::cbor_to_json_str,
 };
 
 pub type MD5Hash = [u8; 16];
 
 #[derive(Debug)]
-pub struct RodeoServer<MDT>
-where
-  for<'de2> MDT: MetaData<'de2>,
-{
+pub struct RodeoServer {
   threads: Mutex<Vec<JoinHandle<()>>>,
-  cluster: Arc<ArcSwap<GoatRodeoCluster<MDT>>>,
+  cluster: Arc<ArcSwap<GoatRodeoCluster>>,
   args: Args,
   config_table: ArcSwap<Table>,
   sender: Sender<IndexMsg>,
   receiver: Receiver<IndexMsg>,
 }
 
-impl RodeoServer<Value> {
+impl RodeoServer {
   pub fn find(&self, hash: MD5Hash) -> Result<Option<ItemOffset>> {
     self.cluster.load().find(hash)
   }
 
-   /// get the cluster arc swap so that the cluster can be substituted
-   pub fn get_cluster_arcswap(&self) -> Arc<ArcSwap<GoatRodeoCluster<Value>>> {
+  /// get the cluster arc swap so that the cluster can be substituted
+  pub fn get_cluster_arcswap(&self) -> Arc<ArcSwap<GoatRodeoCluster>> {
     self.cluster.clone()
   }
 
   /// Get the current GoatRodeoCluster from the the server
-  pub fn get_cluster(&self) -> GoatRodeoCluster<Value> {
-    let the_cluster: GoatRodeoCluster<Value> = (&(**self.get_cluster_arcswap().load())).clone();
+  pub fn get_cluster(&self) -> GoatRodeoCluster {
+    let the_cluster: GoatRodeoCluster = (&(**self.get_cluster_arcswap().load())).clone();
     the_cluster
   }
 
-  pub fn entry_for(&self, file_hash: u64, offset: u64) -> Result<Item<Value>> {
+  pub fn entry_for(&self, file_hash: u64, offset: u64) -> Result<Item> {
     self.cluster.load().entry_for(file_hash, offset)
   }
 
-  pub fn data_for_entry_offset(&self, index_loc: &IndexLoc) -> Result<Item<Value>> {
+  pub fn data_for_entry_offset(&self, index_loc: &IndexLoc) -> Result<Item> {
     self.cluster.load().data_for_entry_offset(index_loc)
   }
 
-  pub fn data_for_hash(&self, hash: MD5Hash) -> Result<Item<Value>> {
+  pub fn data_for_hash(&self, hash: MD5Hash) -> Result<Item> {
     self.cluster.load().data_for_hash(hash)
   }
 
-  pub fn data_for_key(&self, data: &str) -> Result<Item<Value>> {
+  pub fn data_for_key(&self, data: &str) -> Result<Item> {
     self.cluster.load().data_for_key(data)
   }
 
-  pub fn antialias_for(&self, data: &str) -> Result<Item<Value>> {
+  pub fn antialias_for(&self, data: &str) -> Result<Item> {
     self.cluster.load().antialias_for(data)
   }
 
@@ -117,13 +113,10 @@ impl RodeoServer<Value> {
     }
   }
 
-  fn contained_by(data: &Item<Value>) -> HashSet<String> {
+  fn contained_by(data: &Item) -> HashSet<String> {
     let mut ret = HashSet::new();
     for edge in data.connections.iter() {
-      if edge.0 == EdgeType::ContainedBy
-        || edge.0 == EdgeType::AliasTo
-        || edge.0 == EdgeType::BuildsTo
-      {
+      if edge.0.is_contained_by_up() || edge.0.is_to_right() {
         ret.insert(edge.1.clone());
       }
     }
@@ -238,7 +231,7 @@ impl RodeoServer<Value> {
     Ok(())
   }
 
-  fn thread_handler_loop(index: Arc<RodeoServer<Value>>) -> Result<()> {
+  fn thread_handler_loop(index: Arc<RodeoServer>) -> Result<()> {
     loop {
       match index.receiver.recv()? {
         IndexMsg::End => {
@@ -292,10 +285,10 @@ impl RodeoServer<Value> {
   /// and an optional set of args. This is meant to be used to create an Index without
   /// a well defined set of Args
   pub fn new_from_cluster(
-    cluster: Arc<ArcSwap<GoatRodeoCluster<Value>>>,
+    cluster: Arc<ArcSwap<GoatRodeoCluster>>,
     num_threads: u16,
     args_opt: Option<Args>,
-  ) -> Result<Arc<RodeoServer<Value>>> {
+  ) -> Result<Arc<RodeoServer>> {
     let (tx, rx) = flume::unbounded();
 
     // do this in a block so the index is released at the end of the block
@@ -336,11 +329,12 @@ impl RodeoServer<Value> {
     Ok(ret)
   }
 
-  pub fn new(args: Args) -> Result<Arc<RodeoServer<Value>>> {
+  pub fn new(args: Args) -> Result<Arc<RodeoServer>> {
     let config_table = args.read_conf_file()?;
 
-    let cluster =
-      Arc::new(ArcSwap::new(Arc::new(GoatRodeoCluster::<Value>::cluster_from_config(args.conf_file()?, &config_table)?)));
+    let cluster = Arc::new(ArcSwap::new(Arc::new(
+      GoatRodeoCluster::cluster_from_config(args.conf_file()?, &config_table)?,
+    )));
 
     RodeoServer::new_from_cluster(cluster, args.num_threads(), Some(args))
   }

--- a/src/server.rs
+++ b/src/server.rs
@@ -6,7 +6,6 @@ use log::info;
 use rouille::{Request, Response, ResponseBody};
 use scopeguard::defer;
 
-use serde_cbor::Value;
 use serde_json::Value as SJValue; // Use log crate when building application
 
 use crate::{
@@ -58,7 +57,7 @@ pub fn value_to_string_array(pv: Result<SJValue>) -> Result<Vec<String>> {
   }
 }
 
-fn serve_bulk(index: &RodeoServer<Value>, bulk_data: Vec<String>) -> Result<Response> {
+fn serve_bulk(index: &RodeoServer, bulk_data: Vec<String>) -> Result<Response> {
   let (rx, tx) = pipe::pipe();
   index.bulk_serve(bulk_data, tx, Instant::now())?;
   Ok(Response {
@@ -70,7 +69,7 @@ fn serve_bulk(index: &RodeoServer<Value>, bulk_data: Vec<String>) -> Result<Resp
 }
 
 pub fn basic_bulk_serve(
-  index: &RodeoServer<Value>,
+  index: &RodeoServer,
   request: &Request,
   start: Instant,
 ) -> Response {
@@ -97,7 +96,7 @@ pub fn basic_bulk_serve(
 }
 
 pub fn north_serve(
-  index: &RodeoServer<Value>,
+  index: &RodeoServer,
   request: &Request,
   path: Option<&str>,
   purls_only: bool,
@@ -143,7 +142,7 @@ pub fn north_serve(
 }
 
 pub fn serve_antialias(
-  index: &RodeoServer<Value>,
+  index: &RodeoServer,
   _request: &Request,
   path: &str,
   start: Instant,
@@ -185,7 +184,7 @@ pub fn fix_path(p: String) -> String {
   p
 }
 
-pub fn line_serve(index: &RodeoServer<Value>, _request: &Request, path: String) -> Response {
+pub fn line_serve(index: &RodeoServer, _request: &Request, path: String) -> Response {
   // FIXME -- deal with getting a raw MD5 hex string
   let hash = md5hash_str(&path);
   match index.data_for_hash(hash) {
@@ -207,7 +206,7 @@ pub fn line_serve(index: &RodeoServer<Value>, _request: &Request, path: String) 
   }
 }
 
-pub fn run_web_server(index: Arc<RodeoServer<Value>>) -> () {
+pub fn run_web_server(index: Arc<RodeoServer>) -> () {
   let addrs = index.the_args().to_socket_addrs();
   info!("Listen on {:?}", addrs);
   rouille::start_server(

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -3,74 +3,13 @@ use std::collections::{BTreeMap, BTreeSet};
 use serde::{Deserialize, Serialize};
 use serde_cbor::Value;
 
-#[derive(Debug, Eq, PartialEq, PartialOrd, Deserialize, Serialize, Clone, Copy, Hash, Ord)]
-pub enum EdgeType {
-  AliasTo,
-  AliasFrom,
-  Contains,
-  ContainedBy,
-  BuildsTo,
-  BuiltFrom,
-}
-
-#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
-pub struct ItemMetaData {
-  pub file_names: BTreeSet<String>,
-  pub file_type: BTreeSet<String>,
-  pub file_sub_type: BTreeSet<String>,
-  pub file_size: Option<i64>,
-  pub extra: BTreeMap<String, BTreeSet<String>>,
-}
-
-impl<'de2> MetaData<'de2> for ItemMetaData {}
-
-impl<'de2> MetaData<'de2> for Value {}
-
-impl Mergeable for ItemMetaData {
-  fn merge(&self, other: ItemMetaData) -> ItemMetaData {
-    ItemMetaData {
-      file_names: {
-        let mut it = self.file_names.clone();
-        it.extend(other.file_names);
-        it
-      },
-      file_type: {
-        let mut it = self.file_type.clone();
-        it.extend(other.file_type.clone());
-        it
-      },
-      file_sub_type: {
-        let mut it = self.file_sub_type.clone();
-        it.extend(other.file_sub_type.clone());
-        it
-      },
-      file_size: self.file_size,
-      extra: {
-        let mut it = self.extra.clone();
-        for (k, v) in other.extra.iter() {
-          let v = v.clone();
-          let the_val = match it.get(k) {
-            Some(mine) => {
-              let mut tmp = mine.clone();
-              tmp.extend(v);
-              tmp
-            }
-            None => v,
-          };
-
-          it.insert(k.clone(), the_val);
-        }
-        it
-      },
-    }
-  }
-}
 
 pub type LocationReference = (u64, u64);
 
 pub trait Mergeable {
   fn merge(&self, other: Self) -> Self;
 }
+
 
 /// Merge two values
 fn merge_values(v1: &Value, v2: Option<&Value>) -> Value {
@@ -144,30 +83,63 @@ impl Mergeable for Value {
   }
 }
 
-pub type Edge = (EdgeType, String);
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, PartialOrd, Ord, Eq, Hash)]
+pub struct EdgeType(String);
 
-/// A trait that defines the metadata field in an Item
-pub trait MetaData<'a>:
-  Deserialize<'a> + Serialize + PartialEq + Clone + Mergeable + Sized + Send + Sync
-{
+impl EdgeType {
+
+  pub const TO_RIGHT: &str = ":->";
+  pub const FROM_LEFT: &str = ":<-";
+  pub const CONTAINS_DOWN: &str = ":\\/";
+  pub const CONTAINED_BY_UP: &str = ":^";
+
+  pub const CONTAINED_BY: &str = "ContainedBy:^";
+  pub const CONTAINS: &str = "Contains:\\/";
+  pub const ALIAS_TO: &str = "AliasTo:->";
+  pub const ALIAS_FROM: &str = "AliasFrom:<-";
+
+
+  pub fn is_alias_from(&self) -> bool {
+    self.0 == EdgeType::ALIAS_FROM
+  }
+
+  pub fn is_alias_to(&self) -> bool {
+    self.0 == EdgeType::ALIAS_TO
+  }
+
+  pub fn is_from_left(&self) -> bool {
+    self.0.ends_with(EdgeType::FROM_LEFT)
+  }
+
+  pub fn is_to_right(&self) -> bool {
+    self.0.ends_with(EdgeType::TO_RIGHT)
+  }
+
+  pub fn is_contains_down(&self) -> bool {
+    self.0.ends_with(EdgeType::CONTAINS_DOWN)
+  }
+
+  pub fn is_contained_by_up(&self) -> bool {
+    self.0.ends_with(EdgeType::CONTAINED_BY_UP)
+  }
+
 }
 
+pub type Edge = (EdgeType, String);
+
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
-pub struct Item<MDT>
-where
-  for<'de2> MDT: MetaData<'de2>,
+pub struct Item
 {
   pub identifier: String,
   pub reference: LocationReference,
   pub connections: BTreeSet<Edge>,
-  #[serde(bound(deserialize = "Option<MDT>: Deserialize<'de>"))]
-  pub metadata: Option<MDT>,
+  pub body_mime_type: Option<String>,
+  pub body: Option<Value>,
   pub merged_from: BTreeSet<LocationReference>,
 }
 
-impl<MDT> Item<MDT>
-where
-  for<'de2> MDT: MetaData<'de2>,
+impl Item
 {
   pub const NOOP: LocationReference = (0u64, 0u64);
 
@@ -178,7 +150,7 @@ where
       .connections
       .iter()
       // find all aliases to this thing that start with `pkg:`
-      .filter(|c| c.0 == EdgeType::AliasFrom && c.1.starts_with("pkg:"))
+      .filter(|c| c.0.is_alias_from() && c.1.starts_with("pkg:"))
       // make into a string
       .map(|c| c.1.clone())
       // turn into a Vec<String>
@@ -186,24 +158,33 @@ where
   }
 
   pub fn is_alias(&self) -> bool {
-    self.connections.iter().any(|v| v.0 == EdgeType::AliasTo)
+    self.connections.iter().any(|v| v.0.is_alias_to())
   }
   pub fn remove_references(&mut self) {
-    self.reference = Item::<MDT>::NOOP;
+    self.reference = Item::NOOP;
     self.merged_from = BTreeSet::new();
   }
 
   // tests two items... they are the same if they have the same
   // `identifier`, `connections`, `metadata`, `version`,
   // and `_type`
-  pub fn is_same(&self, other: &Item<MDT>) -> bool {
+  pub fn is_same(&self, other: &Item) -> bool {
     self.identifier == other.identifier
       && self.connections == other.connections
-      && self.metadata == other.metadata
+      && self.body_mime_type == other.body_mime_type
+      && self.body == other.body
   }
 
   // merge to `Item`s
-  pub fn merge(&self, other: Item<MDT>) -> Item<MDT> {
+  pub fn merge(&self, other: Item) -> Item {
+    let (body, mime_type) = match (&self.body, other.body, self.body_mime_type == other.body_mime_type) {
+      (None, None, _) => (None, None),
+      (None, Some(a), _) => (Some(a), other.body_mime_type.clone()),
+      (Some(a), None, _) => (Some(a.clone()), self.body_mime_type.clone()),
+      (Some(a), Some(b), true) => (Some(a.merge(b)), self.body_mime_type.clone()),
+      _ => (self.body.clone(), self.body_mime_type.clone())
+    };
+
     Item {
       identifier: self.identifier.clone(),
       reference: self.reference,
@@ -212,19 +193,15 @@ where
         it.extend(other.connections);
         it
       },
-      metadata: match (&self.metadata, other.metadata) {
-        (None, None) => None,
-        (None, Some(a)) => Some(a),
-        (Some(a), None) => Some(a.clone()),
-        (Some(a), Some(b)) => Some(a.merge(b)),
-      },
+      body_mime_type: mime_type,
+      body: body,
       merged_from: self.merged_from.clone(),
     }
   }
 
   // merges this item and returns a new item with `merged_from` set
   // correctly if there were changes
-  pub fn merge_vecs(items: Vec<Item<MDT>>) -> ItemMergeResult<MDT> {
+  pub fn merge_vecs(items: Vec<Item>) -> ItemMergeResult {
     let len = items.len();
     if len <= 1 {
       return ItemMergeResult::Same;
@@ -250,14 +227,9 @@ where
   }
 }
 
-pub enum ItemMergeResult<MDT>
-where
-  for<'de> MDT: MetaData<'de>,
+pub enum ItemMergeResult
 {
   Same,
   ContainsAll(LocationReference),
-  New(Item<MDT>),
+  New(Item),
 }
-
-/// The Item<ItemMetaData> type that replaces the old baked in Item
-pub type MDItem = Item<ItemMetaData>;


### PR DESCRIPTION
DO NOT MERGE

This is the first of more than 1 PR related to this change as it's significant.

### 💻 Description of Change(s) (w/ context)

moved Big Tent to serve the Body (formerly ItemMetaData) with a mime type rather than being generic. This means that BigTent can serve any Body that can be CBOR encoded. Also moved from explicit Enum for Connections to text plus a directional suffix. This expands connections beyond Aliases, Contained, and Compiled

### 🧠 Rationale Behind Change(s)
Rather than having different versions of Big Tent for each type of "ItemMetaData", just treat the contents of the record as
a "body" that has a mime type and is a CBOR (on disk) or JSON (in HTTP responses).

Thus a single Big Tent instance can serve many different data types.

Also change Connection from an enumeration to String with some "direction of connection" suffixes to denote Left/Right relationships (e.g., Aliases) as well as Up/Down relationships (Contains, ContainedBy)

### 📝 Test Plan
Passes all existing tests

### 📜 Documentation
What documentation did you add or update? 
Was the documentation appropriate for the scope of this change?

### 💣 Quality Control
(All items must be checked before a PR is merged)
Did you…
- [ ] Mention an issue number in the PR title?
- [ ] Update the version # in the build file?
- [ ] Create new and/or update relevant existing tests?
- [ ] Create or update relevant documentation and/or diagrams?
- [ ] Comment your code?
- [ ] Fix any stray verbose logging (removing, or moving to debug / trace level)?

### Before Merging…
- Make sure the Quality Control boxes are all ticked
- Make sure any open comments or conversations on the PR are resolved
