### PR TITLE
build: automatically set the version from git tags

### DIFF
--- a/.github/workflows/rust_container_publishing.yml
+++ b/.github/workflows/rust_container_publishing.yml
@@ -46,6 +46,15 @@ jobs:
           run: |
             echo "short_git_hash=$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV" 
             echo "git_branch=$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV" 
+        - name: Set crate version
+          shell: bash
+          run: |
+            last_version_tag="$(git log --format="%D" | perl -ne '/tag: (v[^, )]+)/ and print $1 and exit or print "v0.0.1" and exit')"
+            dirty="$(git diff --quiet || echo -- -dirty)"
+            snapshot="$(git diff --quiet $last_version_tag || echo -- -SNAPSHOT)"
+            rev_version="$(echo $last_version_tag$dirty$snapshot | sed -e 's/^v//')"
+            echo "rev_version=$rev_version" >> "$GITHUB_ENV"
+            sed -i -e "s/^version = .*/version = \"$rev_version\"/" Cargo.toml
         - name: Log in to Docker Hub
           uses: docker/login-action@v3
           with:


### PR DESCRIPTION
### 💻 Description of Change(s) (w/ context)
A script in the github action to set the cargo version for the package.

### 🧠 Rationale Behind Change(s)
This is not as smooth as the SBT plugin, since it has to edit a file rather than becoming the one source of truth, but for all built binaries in CI, the version number will be set correctly.
