### PR TITLE
Run CI on tags for release (and manually too if desired)

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -2,6 +2,7 @@
 name: Rust Build & Test
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - "main"

--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -3,9 +3,14 @@ name: Rust Build & Test
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - "main"
   pull_request:
-    branches: [ "main" ]
+    branches:
+      - "main"
+  release:
+    types: 
+      - "published"
 
 env:
   CARGO_TERM_COLOR: always

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "bigtent"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bigtent"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 authors = ["David Pollak <feeder.of.the.bears@gmail.com>"]
 rust-version = "1.81.0"


### PR DESCRIPTION
This should let us catch up releases and debug CI a bit better