### PR TITLE
Revert "Merge pull request #37"

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -30,14 +30,3 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: RUST_BACKTRACE=1 cargo test --verbose --lib
-    - name: Record Check Status
-      run: |
-        curl -L -X POST \
-          -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{ github.token }}"\
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          -F 'name=Tests' \
-          -F 'head_sha=${{ github.event.pull_request.head.sha }}' \
-          -F 'status=complete' \
-          -F 'output[title]=Tests pass' \
-          https://api.github.com/repos/${{ github.repository }}/check-runs \

--- a/.github/workflows/rust_container_publishing.yml
+++ b/.github/workflows/rust_container_publishing.yml
@@ -1,16 +1,14 @@
 name: Publish Container Images
 
 on:
-  release:
-    types:
-      - "published"
   workflow_run:
-    workflows: 
-      - "Rust Build & Test"
+    workflows: ["Rust Build & Test"]
     types:
       - "completed"
-    branches:
+    branches: 
       - "main"
+    tags: 
+      - "v*.*.*"
   
 env:
   REGISTRY: ghcr.io
@@ -20,6 +18,7 @@ jobs:
     push_to_registry:
       name: Push Docker image to Docker Hub
       runs-on: ubuntu-latest
+      if: ${{ github.event.workflow_run.conclusion == 'success' }}
       permissions:
         packages: write
         contents: read


### PR DESCRIPTION
Turns out a check is emitted from CI runs called merely "build" and github's UI was really feisty about exposing this fact. 