### PR TITLE
Mark v0.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "bigtent"
-version = "0.7.5"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bigtent"
-version = "0.7.5"
+version = "0.8.2"
 edition = "2021"
 authors = ["David Pollak <feeder.of.the.bears@gmail.com>"]
 rust-version = "1.82.0"


### PR DESCRIPTION
Since v0.8.0 and v0.8.1 never got commits changing the built-in version number, I'm jumping those and we can release 0.8.2 with the version number internally correct.