### PR TITLE
Flatten endpoints, etc.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,9 +311,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -673,9 +673,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hex-literal"
-version = "0.4.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+checksum = "bcaaec4551594c969335c98c903c1397853d4198408ea609190f420500f6be71"
 
 [[package]]
 name = "http"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,9 @@ md5 = "0.7.0"
 sha2 = "0.10.8"
 hex = "0.4.3"
 bytes = "1.10"
-hex-literal = "0.4"
+hex-literal = "1"
 shellexpand = "3.1.0"
-chrono = "0.4"
+chrono = "=0.4.39"
 
 # Web Framework stuff
 url = "2.5"
@@ -37,10 +37,12 @@ serde_json = "1.0"
 serde_cbor = "0.11.2"
 axum = {version = "0.8", features = ["json", "macros"]}
 axum-streams = {version="0.20", features=["json", "csv"]}
+# tower = "0.5"
+# tower-http = {version = "0.6", features=["trace"]}
+# tracing = "0.1"
+# tracing-subscriber = { version = "0.3", features=["env-filter"] }
 futures = "0.3"
 im = { version = "15.1.0", features = ["serde"] }
-# tracing = "0.1.40"
-# tracing-subscriber = { version = "0.3.18", features = ["env-filter"]}
 
 
 # Execution stuff

--- a/src/cluster_holder.rs
+++ b/src/cluster_holder.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use crate::{config::Args, rodeo::GoatRodeoCluster};
 #[cfg(test)]
 use std::println as info;
-use toml::{Table, map::Map};
+use toml::{map::Map, Table};
 
 #[derive(Debug, Clone)]
 pub struct ClusterHolder {

--- a/src/cluster_holder.rs
+++ b/src/cluster_holder.rs
@@ -54,7 +54,7 @@ impl ClusterHolder {
     if false {
       // dunno if this is a good idea...
       info!("Loading full index...");
-      cluster.load().get_index().await?;
+      cluster.load().get_md5_to_item_offset_index().await?;
       info!("Loaded index")
     }
 

--- a/src/cluster_writer.rs
+++ b/src/cluster_writer.rs
@@ -10,7 +10,7 @@ use std::{
 #[cfg(test)]
 use std::{println as info, println as trace};
 
-use anyhow::{Result, bail};
+use anyhow::{bail, Result};
 
 use crate::{
   data_file::DataFileEnvelope,
@@ -19,8 +19,8 @@ use crate::{
   sha_writer::ShaWriter,
   structs::Item,
   util::{
-    MD5Hash, byte_slice_to_u63, md5hash_str, path_plus_timed, sha256_for_slice, write_envelope,
-    write_int, write_long, write_short_signed,
+    byte_slice_to_u63, md5hash_str, path_plus_timed, sha256_for_slice, write_envelope, write_int,
+    write_long, write_short_signed, MD5Hash,
   },
 };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, bail};
+use anyhow::{bail, Result};
 use clap::Parser;
 use std::{
   net::{SocketAddr, ToSocketAddrs},

--- a/src/data_file.rs
+++ b/src/data_file.rs
@@ -41,7 +41,7 @@ pub const GOAT_RODEO_CLUSTER_FILE_SUFFIX: &str = "grc";
 
 impl DataFile {
   pub async fn new(dir: &PathBuf, hash: u64) -> Result<DataFile> {
-    let mut data_file = GoatRodeoCluster::find_file(dir, hash, GOAT_RODEO_DATA_FILE_SUFFIX).await?;
+    let mut data_file = GoatRodeoCluster::find_data_or_index_file_from_sha256(dir, hash, GOAT_RODEO_DATA_FILE_SUFFIX).await?;
 
     let dfp: &mut File = &mut data_file;
     let magic = read_u32(dfp).await?;

--- a/src/data_file.rs
+++ b/src/data_file.rs
@@ -3,7 +3,7 @@ use crate::{
   structs::Item,
   util::{read_cbor_sync, read_len_and_cbor, read_u32, read_u32_sync},
 };
-use anyhow::{Result, anyhow, bail};
+use anyhow::{anyhow, bail, Result};
 use serde::{Deserialize, Serialize};
 use std::{
   collections::{BTreeMap, BTreeSet},
@@ -41,7 +41,9 @@ pub const GOAT_RODEO_CLUSTER_FILE_SUFFIX: &str = "grc";
 
 impl DataFile {
   pub async fn new(dir: &PathBuf, hash: u64) -> Result<DataFile> {
-    let mut data_file = GoatRodeoCluster::find_data_or_index_file_from_sha256(dir, hash, GOAT_RODEO_DATA_FILE_SUFFIX).await?;
+    let mut data_file =
+      GoatRodeoCluster::find_data_or_index_file_from_sha256(dir, hash, GOAT_RODEO_DATA_FILE_SUFFIX)
+        .await?;
 
     let dfp: &mut File = &mut data_file;
     let magic = read_u32(dfp).await?;

--- a/src/index_file.rs
+++ b/src/index_file.rs
@@ -39,7 +39,7 @@ impl IndexFile {
   pub async fn new(dir: &PathBuf, hash: u64, check_hash: bool) -> Result<IndexFile> {
     // ensure we close `file` after computing the hash
     if check_hash {
-      let mut file = GoatRodeoCluster::find_file(&dir, hash, GOAT_RODEO_INDEX_FILE_SUFFIX).await?;
+      let mut file = GoatRodeoCluster::find_data_or_index_file_from_sha256(&dir, hash, GOAT_RODEO_INDEX_FILE_SUFFIX).await?;
 
       let tested_hash = byte_slice_to_u63(&sha256_for_reader(&mut file).await?)?;
       if tested_hash != hash {
@@ -51,7 +51,7 @@ impl IndexFile {
       }
     }
 
-    let mut file = GoatRodeoCluster::find_file(&dir, hash, GOAT_RODEO_INDEX_FILE_SUFFIX).await?;
+    let mut file = GoatRodeoCluster::find_data_or_index_file_from_sha256(&dir, hash, GOAT_RODEO_INDEX_FILE_SUFFIX).await?;
 
     let ifp = &mut file;
     let magic = read_u32(ifp).await?;

--- a/src/index_file.rs
+++ b/src/index_file.rs
@@ -2,9 +2,9 @@ use crate::{
   data_file::GOAT_RODEO_INDEX_FILE_SUFFIX,
   rodeo::{GoatRodeoCluster, IndexFileMagicNumber},
   tokio::io::AsyncSeekExt,
-  util::{MD5Hash, byte_slice_to_u63, read_len_and_cbor, read_u32, sha256_for_reader},
+  util::{byte_slice_to_u63, read_len_and_cbor, read_u32, sha256_for_reader, MD5Hash},
 };
-use anyhow::{Result, bail};
+use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 use std::{
   collections::{BTreeMap, HashSet},
@@ -39,7 +39,12 @@ impl IndexFile {
   pub async fn new(dir: &PathBuf, hash: u64, check_hash: bool) -> Result<IndexFile> {
     // ensure we close `file` after computing the hash
     if check_hash {
-      let mut file = GoatRodeoCluster::find_data_or_index_file_from_sha256(&dir, hash, GOAT_RODEO_INDEX_FILE_SUFFIX).await?;
+      let mut file = GoatRodeoCluster::find_data_or_index_file_from_sha256(
+        &dir,
+        hash,
+        GOAT_RODEO_INDEX_FILE_SUFFIX,
+      )
+      .await?;
 
       let tested_hash = byte_slice_to_u63(&sha256_for_reader(&mut file).await?)?;
       if tested_hash != hash {
@@ -51,7 +56,12 @@ impl IndexFile {
       }
     }
 
-    let mut file = GoatRodeoCluster::find_data_or_index_file_from_sha256(&dir, hash, GOAT_RODEO_INDEX_FILE_SUFFIX).await?;
+    let mut file = GoatRodeoCluster::find_data_or_index_file_from_sha256(
+      &dir,
+      hash,
+      GOAT_RODEO_INDEX_FILE_SUFFIX,
+    )
+    .await?;
 
     let ifp = &mut file;
     let magic = read_u32(ifp).await?;

--- a/src/live_merge.rs
+++ b/src/live_merge.rs
@@ -42,7 +42,7 @@ pub async fn perform_merge(clusters: Vec<GoatRodeoCluster>) -> Result<GoatRodeoC
   let mut max_size = 0usize;
 
   for cluster in &clusters {
-    let index = cluster.get_index().await?;
+    let index = cluster.get_md5_to_item_offset_index().await?;
     let index_len = index.len();
     max_size += index_len;
     index_holder.push(ClusterPos {

--- a/src/live_merge.rs
+++ b/src/live_merge.rs
@@ -4,10 +4,10 @@ use std::{collections::HashMap, time::Instant}; // Use log crate when building a
 
 use crate::{
   index_file::{IndexLoc, ItemOffset},
-  mod_share::{ClusterPos, update_top},
+  mod_share::{update_top, ClusterPos},
   rodeo::GoatRodeoCluster,
 };
-use anyhow::{Result, bail};
+use anyhow::{bail, Result};
 use im::OrdMap;
 #[cfg(test)]
 use std::println as info;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, bail};
+use anyhow::{bail, Result};
 use arc_swap::ArcSwap;
 use bigtent::{
   cluster_holder::ClusterHolder, config::Args, merger::merge_fresh, rodeo::GoatRodeoCluster,
@@ -10,16 +10,19 @@ use env_logger::Env;
 use log::{error, info}; // Use log crate when building application
 
 use signal_hook::{consts::SIGHUP, iterator::Signals};
-use thousands::Separable;
 use std::{path::PathBuf, sync::Arc, thread, time::Instant};
 #[cfg(test)]
 use std::{println as info, println as error};
+use thousands::Separable;
 
 async fn run_rodeo(path: &PathBuf, args: &Args) -> Result<()> {
   if path.exists() && path.is_file() {
     let whole_path = path.clone().canonicalize()?;
     let dir_path = whole_path.parent().unwrap().to_path_buf();
-    info!("Single cluster server for {:?} with dir_path {:?}", whole_path, dir_path);
+    info!(
+      "Single cluster server for {:?} with dir_path {:?}",
+      whole_path, dir_path
+    );
     let index_build_start = Instant::now();
     let cluster = Arc::new(ArcSwap::new(Arc::new(
       GoatRodeoCluster::new(&dir_path, &whole_path).await?,
@@ -27,7 +30,10 @@ async fn run_rodeo(path: &PathBuf, args: &Args) -> Result<()> {
 
     info!("Forcing full index read");
     let built_index = cluster.load().get_md5_to_item_offset_index().await?;
-    info!("Index read complete, len {}", built_index.len().separate_with_commas());
+    info!(
+      "Index read complete, len {}",
+      built_index.len().separate_with_commas()
+    );
 
     let cluster_holder = ClusterHolder::new_from_cluster(cluster, Some(args.clone())).await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ async fn run_rodeo(path: &PathBuf, args: &Args) -> Result<()> {
     )));
 
     info!("Forcing full index read");
-    let built_index = cluster.load().get_index().await?;
+    let built_index = cluster.load().get_md5_to_item_offset_index().await?;
     info!("Index read complete, len {}", built_index.len().separate_with_commas());
 
     let cluster_holder = ClusterHolder::new_from_cluster(cluster, Some(args.clone())).await?;

--- a/src/merger.rs
+++ b/src/merger.rs
@@ -13,7 +13,7 @@ use std::println as info;
 
 use crate::{
   cluster_writer::ClusterWriter,
-  mod_share::{ClusterPos, update_top},
+  mod_share::{update_top, ClusterPos},
   rodeo::GoatRodeoCluster,
   structs::Item,
   util::{MD5Hash, NiceDurationDisplay},

--- a/src/rodeo.rs
+++ b/src/rodeo.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result, bail};
+use anyhow::{bail, Context, Result};
 use arc_swap::ArcSwap;
 use scopeguard::defer;
 use serde::{Deserialize, Serialize};
@@ -6,16 +6,16 @@ use std::{
   collections::{BTreeMap, HashMap, HashSet},
   ops::Deref,
   path::{Path, PathBuf},
-  sync::{Arc, atomic::AtomicU32},
+  sync::{atomic::AtomicU32, Arc},
   time::Instant,
 };
 use thousands::Separable;
 use tokio::{
-  fs::{File, read_dir},
+  fs::{read_dir, File},
   io::BufReader,
   sync::{
-    Mutex,
     mpsc::{Receiver, Sender},
+    Mutex,
   },
 };
 use toml::Table; // Use log crate when building application
@@ -26,8 +26,8 @@ use crate::{
   live_merge::perform_merge,
   structs::{EdgeType, Item},
   util::{
-    MD5Hash, byte_slice_to_u63, find_common_root_dir, hex_to_u64, is_child_dir, md5hash_str,
-    read_len_and_cbor, read_u32, sha256_for_reader, sha256_for_slice,
+    byte_slice_to_u63, find_common_root_dir, hex_to_u64, is_child_dir, md5hash_str,
+    read_len_and_cbor, read_u32, sha256_for_reader, sha256_for_slice, MD5Hash,
   },
 };
 #[cfg(not(test))]
@@ -409,7 +409,14 @@ impl GoatRodeoCluster {
     ret
   }
 
-  pub async fn get_index(&self) -> Result<Arc<EitherItemOffsetVec>> {
+  /// Big Tent has an in-memory index of MD5 hash of identifier to the
+  /// location (`ItemOffset`) of the indexed `Item`. This function
+  /// returns the index. If the index has not been loaded from disk
+  /// (loading in all the `.gri` files referenced in the `.grc` cluster definition)
+  /// the items are loaded. The load process can take a while (3+ minutes for 2B
+  /// index entries). If there are multiple threads, waiting on the load,
+  /// only one will actually do the load
+  pub async fn get_md5_to_item_offset_index(&self) -> Result<Arc<EitherItemOffsetVec>> {
     // get the index
     let tmp = self.index.load().clone();
 
@@ -538,14 +545,28 @@ impl GoatRodeoCluster {
     Ok(ret_arc)
   }
 
-  pub fn data_file(&self, hash: u64) -> Result<Arc<Mutex<Box<dyn DataReader>>>> {
+  /// Data files (files that contain `Item`s) are named based on the 8 most significant
+  /// bytes of their sha256 (with the most significant bit set to 0). This data structure
+  /// opens each of the data files so that when an `Item` needs to be read, the
+  /// `Mutex`ed file handle can be looked up in a hash table. This function
+  /// Does the lookup
+  pub fn find_data_file_from_sha256(&self, hash: u64) -> Result<Arc<Mutex<Box<dyn DataReader>>>> {
     match self.data_files.get(&hash) {
       Some(df) => Ok(df.file.clone()),
       None => bail!("Data file '{:016x}.grd' not found", hash),
     }
   }
 
-  pub async fn find_file(path: &PathBuf, hash: u64, suffix: &str) -> Result<File> {
+  /// Big Tent and Goat Rodeo store data and index files with names based on the
+  /// sha256 of the file contents. This function, given a root_path, finds
+  /// the file with the correct hash. Note that this is the most significant
+  /// 8 bytes of the sha256 with the most significant bit set to zero. This
+  /// is because the JVM's `long` is signed
+  pub async fn find_data_or_index_file_from_sha256(
+    root_path: &PathBuf,
+    hash: u64,
+    suffix: &str,
+  ) -> Result<File> {
     fn find(name: &str, dir: &Path) -> Result<Option<PathBuf>> {
       for entry in dir.read_dir()?.into_iter() {
         let entry = entry?;
@@ -568,12 +589,13 @@ impl GoatRodeoCluster {
       Ok(None)
     }
     let file_name = format!("{:016x}.{}", hash, suffix);
-    match find(&file_name, path)? {
+    match find(&file_name, root_path)? {
       Some(f) => Ok(File::open(f).await?),
-      _ => bail!("Couldn't find {} in {:?}", file_name, path),
+      _ => bail!("Couldn't find {} in {:?}", file_name, root_path),
     }
   }
 
+  /// Given a path, find all the `.grc` files in the path
   pub async fn cluster_files_in_dir(path: PathBuf) -> Result<Vec<GoatRodeoCluster>> {
     let mut the_dir = read_dir(path.clone()).await?;
     let mut ret = vec![];
@@ -602,12 +624,25 @@ impl GoatRodeoCluster {
     Ok(ret)
   }
 
-  pub async fn find(&self, hash: MD5Hash) -> Result<Option<EitherItemOffset>> {
-    let index = self.get_index().await?;
+  /// given an identifier, convert it into a hash and then look up the hash in the
+  /// index. This is a fast operation as it's just a binary search of the index which is
+  /// in memory
+  pub async fn identifier_to_item_offset(
+    &self,
+    identifier: &str,
+  ) -> Result<Option<EitherItemOffset>> {
+    let hash = md5hash_str(identifier);
+    Ok(self.hash_to_item_offset(hash).await?)
+  }
+
+  /// from a hash, find the ItemOffset
+  pub async fn hash_to_item_offset(&self, hash: MD5Hash) -> Result<Option<EitherItemOffset>> {
+    let index = self.get_md5_to_item_offset_index().await?;
     Ok(index.find(hash))
   }
 
-  pub async fn entry_for(&self, file_hash: u64, offset: u64) -> Result<Item> {
+  /// given a hash, find an item
+  pub async fn hash_to_item(&self, file_hash: u64, offset: u64) -> Result<Item> {
     let data_files = &self.data_files;
     let data_file = data_files.get(&file_hash);
     match data_file {
@@ -622,43 +657,73 @@ impl GoatRodeoCluster {
     }
   }
 
-  /// create a stream for the flattened items
+  /// create a stream for the flattened items. If any of the `gitoids` cannot
+  /// be found, an `Err` is put in the stream and the flattening is completed.
+  ///
+  /// If `source` is true, the flattening includes "built from" and the returned
+  /// items are the items that the code was built from
   pub async fn stream_flattened_items(
     self: Arc<GoatRodeoCluster>,
     gitoids: Vec<String>,
+    source: bool,
   ) -> Result<Receiver<serde_json::Value>> {
     let (tx, rx) = tokio::sync::mpsc::channel::<serde_json::Value>(256);
+    let mut to_find = HashSet::new();
+    let mut not_found = vec![];
 
-    tokio::spawn(async move {
-      let mut to_find = HashSet::new();
-      for s in gitoids {
-        to_find.insert(s);
+    for s in gitoids {
+      match self.identifier_to_item_offset(&s).await {
+        Ok(Some(_)) => {
+          to_find.insert(s);
+        }
+        _ => {
+          not_found.push(s);
+        }
       }
-      let mut found = HashSet::new();
+    }
+
+    if !not_found.is_empty() {
+      bail!("The following items are not found {:?}", not_found);
+    }
+
+    // populate the channel
+    tokio::spawn(async move {
+      let mut processed = HashSet::new();
       while !to_find.is_empty() {
         let mut new_to_find = HashSet::new();
-        for gitoid in to_find.clone() {
-          match self.data_for_key(&gitoid).await {
-            Ok(item) => {
+        for identifier in to_find.clone() {
+          match self.item_for_identifier(&identifier).await {
+            Ok(Some(item)) => {
+              // deal with anti-aliasing
               item
                 .connections
                 .iter()
                 .filter(|a| a.0.is_alias_to())
                 .for_each(|s| {
-                  if !to_find.contains(&s.1) && found.contains(&s.1) {
+                  if !to_find.contains(&s.1) && !processed.contains(&s.1) {
                     new_to_find.insert(s.1.clone());
                   }
                 });
-              for s in item.connections.iter().filter(|a| a.0.is_contains_down()) {
-                if !to_find.contains(&s.1) && found.contains(&s.1) {
+
+              // process
+              for s in item
+                .connections
+                .iter()
+                .filter(|a| a.0.is_contains_down() || (source && a.0.is_built_from()))
+              {
+                if !to_find.contains(&s.1) && !processed.contains(&s.1) {
                   new_to_find.insert(s.1.clone());
-                  let _ = tx.send(s.1.clone().into()).await;
+
+                  // if we are looking at source only, only include build sources
+                  if !source || s.0.is_built_from() {
+                    let _ = tx.send(s.1.clone().into()).await;
+                  }
                 }
               }
             }
-            Err(_) => {}
+            _ => {}
           }
-          found.insert(gitoid);
+          processed.insert(identifier);
         }
 
         to_find = new_to_find;
@@ -702,8 +767,8 @@ impl GoatRodeoCluster {
       }
       for this_oid in to_search {
         found.insert(this_oid.clone());
-        match self.data_for_key(&this_oid).await {
-          Ok(item) => {
+        match self.item_for_identifier(&this_oid).await {
+          Ok(Some(item)) => {
             let and_then = item.contained_by();
             if purls_only {
               for purl in item.find_purls() {
@@ -727,12 +792,21 @@ impl GoatRodeoCluster {
     Ok(())
   }
 
-  pub async fn antialias_for(&self, data: &str) -> Result<Item> {
-    let mut ret = self.data_for_key(data).await?;
+  pub async fn antialias_for(&self, data: &str) -> Result<Option<Item>> {
+    let mut ret = match self.item_for_identifier(data).await? {
+      Some(i) => i,
+      _ => return Ok(None),
+    };
     while ret.is_alias() {
       match ret.connections.iter().find(|x| x.0.is_alias_to()) {
         Some(v) => {
-          ret = self.data_for_key(&v.1).await?;
+          ret = match self.item_for_identifier(&v.1).await? {
+            Some(v) => v,
+            _ => bail!(
+              "Expecting to traverse from {}, but no aliases found",
+              ret.identifier
+            ),
+          };
         }
         None => {
           bail!("Unexpected situation");
@@ -740,14 +814,14 @@ impl GoatRodeoCluster {
       }
     }
 
-    Ok(ret)
+    Ok(Some(ret))
   }
 
   pub async fn data_for_entry_offset(&self, index_loc: &IndexLoc) -> Result<Item> {
     match index_loc {
       loc @ IndexLoc::Loc(_) => Ok(
         self
-          .entry_for(loc.get_file_hash(), loc.get_offset())
+          .hash_to_item(loc.get_file_hash(), loc.get_offset())
           .await?,
       ),
       IndexLoc::Chain(offsets) => {
@@ -781,7 +855,7 @@ impl GoatRodeoCluster {
     match index_loc {
       loc @ IndexLoc::Loc(_) => Ok(vec![
         self
-          .entry_for(loc.get_file_hash(), loc.get_offset())
+          .hash_to_item(loc.get_file_hash(), loc.get_offset())
           .await?,
       ]),
       IndexLoc::Chain(offsets) => {
@@ -795,18 +869,22 @@ impl GoatRodeoCluster {
     }
   }
 
-  pub async fn data_for_hash(&self, hash: MD5Hash) -> Result<Item> {
-    let entry_offset = match self.find(hash).await? {
-      Some(eo) => eo,
-      _ => bail!(format!("Could not find entry for hash {:x?}", hash)),
-    };
-
-    self.data_for_entry_offset(&entry_offset.loc()).await
+  pub async fn item_for_hash(&self, hash: MD5Hash, original: Option<&str>) -> Result<Option<Item>> {
+    match self.hash_to_item_offset(hash).await? {
+      Some(eo) => Ok(Some(self.data_for_entry_offset(&eo.loc()).await?)),
+      _ => match original {
+        Some(id) => bail!(format!(
+          "Could not find `Item` for identifier {} hash {:x?}",
+          id, hash
+        )),
+        _ => bail!(format!("Could not find `Item` for hash {:x?}", hash)),
+      },
+    }
   }
 
-  pub async fn data_for_key(&self, data: &str) -> Result<Item> {
+  pub async fn item_for_identifier(&self, data: &str) -> Result<Option<Item>> {
     let md5_hash = md5hash_str(data);
-    self.data_for_hash(md5_hash).await
+    self.item_for_hash(md5_hash, Some(data)).await
   }
 }
 
@@ -833,7 +911,7 @@ async fn test_antialias() {
   assert!(files.len() > 0, "Need a cluster");
   let cluster = files.pop().expect("Expect a cluster");
   let index = cluster
-    .get_index()
+    .get_md5_to_item_offset_index()
     .await
     .expect("To be able to get the index")
     .flatten();
@@ -841,9 +919,10 @@ async fn test_antialias() {
   let mut aliases = vec![];
   for v in index.iter() {
     let item = cluster
-      .data_for_hash(*v.hash())
+      .item_for_hash(*v.hash(), None)
       .await
-      .expect("Should get an item");
+      .expect("Should get an item")
+      .expect("And it should be a Some");
     if item.is_alias() {
       aliases.push(item);
     }
@@ -856,7 +935,8 @@ async fn test_antialias() {
     let new_item = cluster
       .antialias_for(&ai.identifier)
       .await
-      .expect("Expect to get the antialiased thing");
+      .expect("Expect to get the antialiased thing")
+      .expect("And it's not a None");
     assert!(!new_item.is_alias(), "Expecting a non-aliased thing");
     assert!(
       new_item
@@ -908,7 +988,7 @@ async fn test_generated_cluster() {
     let mut pass_num = 0;
     for cluster in files {
       pass_num += 1;
-      let complete_index = cluster.get_index().await.unwrap();
+      let complete_index = cluster.get_md5_to_item_offset_index().await.unwrap();
 
       info!(
         "Loaded index for pass {} at {:?}",
@@ -924,7 +1004,11 @@ async fn test_generated_cluster() {
       info!("Index size {}", complete_index.len());
 
       for i in complete_index.deref().flatten() {
-        cluster.find(*i.hash()).await.unwrap().unwrap();
+        cluster
+          .hash_to_item_offset(*i.hash())
+          .await
+          .unwrap()
+          .unwrap();
       }
     }
   }
@@ -956,7 +1040,7 @@ async fn test_files_in_dir() {
     assert!(cluster.index_files.len() > 0);
 
     let start = Instant::now();
-    let complete_index = cluster.get_index().await.unwrap();
+    let complete_index = cluster.get_md5_to_item_offset_index().await.unwrap();
 
     total_index_size += complete_index.len();
 
@@ -967,7 +1051,7 @@ async fn test_files_in_dir() {
     );
     let time = Instant::now().duration_since(start);
     let start = Instant::now();
-    cluster.get_index().await.unwrap(); // should be from cache
+    cluster.get_md5_to_item_offset_index().await.unwrap(); // should be from cache
     let time2 = Instant::now().duration_since(start);
 
     assert!(

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,11 +2,12 @@ use std::{net::SocketAddr, pin::Pin, sync::Arc, time::Instant};
 
 use anyhow::Result;
 use axum::{
-  Json, Router,
-  extract::{Path, State},
-  http::StatusCode,
-  response::IntoResponse,
+  extract::{Path, Request, State},
+  http::{StatusCode, Uri},
+  middleware::{self, Next},
+  response::{IntoResponse, Response},
   routing::{get, post},
+  Json, Router,
 };
 use axum_streams::*;
 
@@ -14,7 +15,7 @@ use axum_streams::*;
 use log::info;
 
 use tokio::sync::mpsc::Receiver;
-use tokio_stream::Stream; // Use log crate when building application
+use tokio_stream::Stream;
 
 use crate::{cluster_holder::ClusterHolder, structs::Item};
 #[cfg(test)]
@@ -25,13 +26,13 @@ async fn stream_items(rodeo: Arc<ClusterHolder>, items: Vec<String>) -> Receiver
 
   tokio::spawn(async move {
     for item_id in items {
-      match rodeo.get_cluster().data_for_key(&item_id).await {
-        Ok(i) => {
+      match rodeo.get_cluster().item_for_identifier(&item_id).await {
+        Ok(Some(i)) => {
           if !mtx.is_closed() {
             let _ = mtx.send(i).await;
           }
         }
-        Err(_) => {}
+        _ => {}
       }
     }
   });
@@ -73,17 +74,37 @@ async fn serve_bulk(
   })
 }
 
+/// compute the package from either uri which will include query parameters (which are part of)
+/// a pURL or the path that was passed in
+fn compute_package(maybe_gitoid: &str, uri: &Uri) -> String {
+  if let Some(pq) = uri.path_and_query() {
+    let path = pq.as_str();
+    let offset = path.find(maybe_gitoid);
+    if let Some(actual_offset) = offset {
+      path[actual_offset..].to_string()
+    } else {
+      path.to_string()
+    }
+  } else {
+    maybe_gitoid.to_string()
+  }
+}
+
+#[axum::debug_handler]
 async fn serve_gitoid(
   State(rodeo): State<Arc<ClusterHolder>>,
   Path(gitoid): Path<String>,
+  uri: Uri,
 ) -> Result<Json<serde_json::Value>, impl IntoResponse> {
-  let ret = rodeo.get_cluster().data_for_key(&gitoid).await;
+  let to_find = compute_package(&gitoid, &uri);
+
+  let ret = rodeo.get_cluster().item_for_identifier(&to_find).await;
 
   match ret {
-    Ok(item) => Ok(Json(item.to_json())),
-    Err(_) => Err((
+    Ok(Some(item)) => Ok(Json(item.to_json())),
+    _ => Err((
       StatusCode::NOT_FOUND,
-      format!("No item found for key {}", gitoid),
+      format!("No item found for key {}", to_find),
     )),
   }
 }
@@ -91,14 +112,16 @@ async fn serve_gitoid(
 async fn serve_anti_alias(
   State(rodeo): State<Arc<ClusterHolder>>,
   Path(gitoid): Path<String>,
+  uri: Uri,
 ) -> Result<Json<serde_json::Value>, impl IntoResponse> {
-  let ret = rodeo.get_cluster().antialias_for(&gitoid).await;
+  let to_find = compute_package(&gitoid, &uri);
+  let ret = rodeo.get_cluster().antialias_for(&to_find).await;
 
   match ret {
-    Ok(item) => Ok(Json(item.to_json())),
-    Err(_) => Err((
+    Ok(Some(item)) => Ok(Json(item.to_json())),
+    _ => Err((
       StatusCode::NOT_FOUND,
-      format!("No item found for key {}", gitoid),
+      format!("No item found for key {}", to_find),
     )),
   }
 }
@@ -106,6 +129,7 @@ async fn serve_anti_alias(
 async fn serve_flatten_both(
   rodeo: Arc<ClusterHolder>,
   payload: Vec<String>,
+  source: bool
 ) -> Result<impl IntoResponse, impl IntoResponse> {
   let start = Instant::now();
   let payload_len = payload.len();
@@ -115,20 +139,40 @@ async fn serve_flatten_both(
   }
 
   let stream: Receiver<serde_json::Value> =
-    match rodeo.get_cluster().stream_flattened_items(payload).await {
+    match rodeo.get_cluster().stream_flattened_items(payload, source).await {
       Ok(s) => s,
-      Err(_e) => return Err((StatusCode::INTERNAL_SERVER_ERROR, "??")),
+      Err(e) => return Err((StatusCode::NOT_FOUND, format!("{}", e))),
     };
   let tok_stream = TokioReceiverToStream { receiver: stream };
 
   Ok(StreamBodyAs::json_array(tok_stream))
 }
 
+async fn serve_flatten_source(
+  State(rodeo): State<Arc<ClusterHolder>>,
+  Path(gitoid): Path<String>,
+  uri: Uri,
+) -> impl IntoResponse {
+  let to_find = compute_package(&gitoid, &uri);
+  serve_flatten_both(rodeo, vec![to_find], true).await
+}
+
+/// Serve all the "contains" gitoids for a given Item
+/// Follows `AliasTo` links
+async fn serve_flatten_source_bulk(
+  State(rodeo): State<Arc<ClusterHolder>>,
+  Json(payload): Json<Vec<String>>,
+) -> impl IntoResponse {
+  serve_flatten_both(rodeo, payload, true).await
+}
+
 async fn serve_flatten(
   State(rodeo): State<Arc<ClusterHolder>>,
   Path(gitoid): Path<String>,
+  uri: Uri,
 ) -> impl IntoResponse {
-  serve_flatten_both(rodeo, vec![gitoid]).await
+  let to_find = compute_package(&gitoid, &uri);
+  serve_flatten_both(rodeo, vec![to_find], false).await
 }
 
 /// Serve all the "contains" gitoids for a given Item
@@ -137,21 +181,25 @@ async fn serve_flatten_bulk(
   State(rodeo): State<Arc<ClusterHolder>>,
   Json(payload): Json<Vec<String>>,
 ) -> impl IntoResponse {
-  serve_flatten_both(rodeo, payload).await
+  serve_flatten_both(rodeo, payload, false).await
 }
 
 async fn serve_north(
   State(rodeo): State<Arc<ClusterHolder>>,
   Path(gitoid): Path<String>,
+  uri: Uri,
 ) -> impl IntoResponse {
-  do_north(rodeo, vec![gitoid], false).await
+  let to_find = compute_package(&gitoid, &uri);
+  do_north(rodeo, vec![to_find], false).await
 }
 
 async fn serve_north_purls(
   State(rodeo): State<Arc<ClusterHolder>>,
   Path(gitoid): Path<String>,
+  uri: Uri,
 ) -> impl IntoResponse {
-  do_north(rodeo, vec![gitoid], true).await
+  let to_find = compute_package(&gitoid, &uri);
+  do_north(rodeo, vec![to_find], true).await
 }
 
 async fn serve_north_bulk(
@@ -202,9 +250,12 @@ pub fn build_route(state: Arc<ClusterHolder>) -> Router {
     .route("/{*gitoid}", get(serve_gitoid))
     .route("/aa/{*gitoid}", get(serve_anti_alias))
     .route("/north/{*gitoid}", get(serve_north))
-    .route("/flatten/{*gitoid}", get(serve_flatten))
+    
     .route("/north_purls/{*gitoid}", get(serve_north_purls))
     .route("/north", post(serve_north_bulk))
+    .route("/flatten_source/{*gitoid}", get(serve_flatten_source))
+    .route("/flatten_source", post(serve_flatten_source_bulk))
+    .route("/flatten/{*gitoid}", get(serve_flatten))
     .route("/flatten", post(serve_flatten_bulk))
     .route("/north_purls", post(serve_north_purls_bulk))
     .with_state(state);
@@ -212,12 +263,29 @@ pub fn build_route(state: Arc<ClusterHolder>) -> Router {
   app
 }
 
+/// middleware for request logging
+pub async fn request_log_middleware(request: Request, next: Next) -> Response {
+  let start = Instant::now();
+  let request_uri_string = format!("{}", request.uri());
+  let response = next.run(request).await;
+
+  info!(
+    "Served {} response {} time {:?}",
+    request_uri_string,
+    response.status(),
+    Instant::now().duration_since(start)
+  );
+
+  response
+}
+
 pub async fn run_web_server(index: Arc<ClusterHolder>) -> Result<()> {
   let state = index.clone();
   let addrs = index.the_args().to_socket_addrs();
   info!("Listen on {:?}", addrs);
 
-  let app = build_route(state);
+  let app = build_route(state)
+    .layer(middleware::from_fn(request_log_middleware));
 
   let nested = Router::new().nest("/omnibor", app.clone());
 

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -90,6 +90,10 @@ pub trait EdgeType {
   fn is_contains_down(&self) -> bool;
 
   fn is_contained_by_up(&self) -> bool;
+
+  fn is_built_from(&self) -> bool;
+
+  fn is_builds_to(&self) -> bool;
 }
 
 pub const TO: &str = ":to";
@@ -101,7 +105,8 @@ pub const CONTAINED_BY: &str = "contained:up";
 pub const CONTAINS: &str = "contained:down";
 pub const ALIAS_TO: &str = "alias:to";
 pub const ALIAS_FROM: &str = "alias:from";
-
+pub const BUILDS_TO: &str = "build:up";
+pub const BUILT_FROM: &str = "build:down";
 impl EdgeType for String {
   fn is_alias_from(&self) -> bool {
     self == ALIAS_FROM
@@ -126,6 +131,16 @@ impl EdgeType for String {
   fn is_contained_by_up(&self) -> bool {
     self.ends_with(CONTAINED_BY)
   }
+  
+  fn is_built_from(&self) -> bool {
+        self.ends_with(BUILT_FROM)
+    }
+  
+  fn is_builds_to(&self) -> bool {
+        self.ends_with(BUILDS_TO)
+    }
+
+
 }
 
 pub type Edge = (String, String);

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -131,16 +131,14 @@ impl EdgeType for String {
   fn is_contained_by_up(&self) -> bool {
     self.ends_with(CONTAINED_BY)
   }
-  
+
   fn is_built_from(&self) -> bool {
-        self.ends_with(BUILT_FROM)
-    }
-  
+    self.ends_with(BUILT_FROM)
+  }
+
   fn is_builds_to(&self) -> bool {
-        self.ends_with(BUILDS_TO)
-    }
-
-
+    self.ends_with(BUILDS_TO)
+  }
 }
 
 pub type Edge = (String, String);

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,7 @@
-use anyhow::{Context, Result, bail};
+use anyhow::{bail, Context, Result};
 #[cfg(not(test))]
 use log::info;
-use serde::{Serialize, de::DeserializeOwned};
+use serde::{de::DeserializeOwned, Serialize};
 use serde_cbor::Value;
 use std::{
   collections::{BTreeMap, HashSet},


### PR DESCRIPTION
### 💻 Description of Change(s) (w/ context)

Added `/flatten_source` ... given an identifier, find all the source gitoids used to build that item

Fixed `/flatten` ... it was not returning any items

For both `/flatten` and `/flatten_source`, 404 if any of the identifiers are not found

Added Request logging

Cleaned up some naming

Added documentation

Fixed a bug that ignored query params... this means that `/omnibor/foo?type=source` will be served correctly rather than trying to serve `foo`
