### PR TITLE
Fixes a bug in non-inmemory indexes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,7 +253,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bigtent"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bigtent"
-version = "0.10.3"
+version = "0.10.4"
 edition = "2024"
 authors = ["David Pollak <feeder.of.the.bears@gmail.com>"]
 rust-version = "1.85.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ async fn run_rodeo(path: &PathBuf, args: &Args) -> Result<()> {
     );
     let index_build_start = Instant::now();
     let cluster = Arc::new(ArcSwap::new(
-      GoatRodeoCluster::new(&dir_path, &whole_path, false).await?,
+      GoatRodeoCluster::new(&dir_path, &whole_path, args.pre_cache_index()).await?,
     ));
 
     let cluster_holder = ClusterHolder::new_from_cluster(cluster, Some(args.clone())).await?;

--- a/src/rodeo/goat_herd.rs
+++ b/src/rodeo/goat_herd.rs
@@ -149,6 +149,14 @@ impl GoatRodeoTrait for GoatHerd {
   fn is_empty(&self) -> bool {
     self.herd.is_empty()
   }
+
+  fn node_count(&self) -> u64 {
+    let mut ret = 0;
+    for goat in &self.herd {
+      ret += goat.node_count();
+    }
+    ret
+  }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]

--- a/src/rodeo/goat_trait.rs
+++ b/src/rodeo/goat_trait.rs
@@ -23,13 +23,15 @@ use crate::{
 /// be implemented for a single cluster or for something holding
 /// a group of clusters
 pub trait GoatRodeoTrait: Clone + Send + Sync {
+  /// get the number of nodes
+  fn node_count(&self) -> u64;
   /// get the purls.txt file
   fn get_purl(&self) -> Result<PathBuf>;
   /// get the number of items this cluster is managing
   fn number_of_items(&self) -> usize;
 
   /// Get the history for the cluster
-  fn read_history(&self) -> Result<Vec<serde_json::Value>> ;
+  fn read_history(&self) -> Result<Vec<serde_json::Value>>;
 
   /// given a `Vec` of identifiers, find all the items that contain those
   /// items, etc. until there's no contents left.
@@ -68,8 +70,6 @@ pub trait GoatRodeoTrait: Clone + Send + Sync {
   /// no clusters
   fn is_empty(&self) -> bool;
 }
-
-
 
 pub async fn impl_stream_flattened_items<GRT: GoatRodeoTrait + 'static>(
   the_self: Arc<GRT>,

--- a/src/server.rs
+++ b/src/server.rs
@@ -88,7 +88,11 @@ async fn serve_bulk<GRT: GoatRodeoTrait + 'static>(
 fn compute_package(maybe_gitoid: &str, uri: &Uri) -> String {
   if let Some(pq) = uri.path_and_query() {
     let path = pq.as_str();
-    let offset = path.find(&maybe_gitoid[0..10]);
+    let offset = if maybe_gitoid.len() > 10 {
+      path.find(&maybe_gitoid[0..10])
+    } else {
+      None
+    };
 
     if let Some(actual_offset) = offset {
       path[actual_offset..].to_string()

--- a/src/server.rs
+++ b/src/server.rs
@@ -100,6 +100,11 @@ fn compute_package(maybe_gitoid: &str, uri: &Uri) -> String {
   }
 }
 
+async fn node_count<GRT: GoatRodeoTrait + 'static>(
+  State(rodeo): State<Arc<ClusterHolder<GRT>>>,
+) -> Result<Json<serde_json::Value>, Json<serde_json::Value>> {
+  Ok(Json(rodeo.get_cluster().node_count().into()))
+}
 // #[axum::debug_handler]
 async fn serve_gitoid<GRT: GoatRodeoTrait + 'static>(
   State(rodeo): State<Arc<ClusterHolder<GRT>>>,
@@ -299,6 +304,7 @@ pub fn build_route<GRT: GoatRodeoTrait + 'static>(state: Arc<ClusterHolder<GRT>>
     .route("/flatten", post(serve_flatten_bulk))
     .route("/north_purls", post(serve_north_purls_bulk))
     .route("/purls", get(gimme_purls))
+    .route("/node_count", get(node_count))
     .with_state(state.clone());
 
   app


### PR DESCRIPTION
Fixed a bug that made lookups in databases with more than 1 index file and not-inmemory index fail.

Added bounds checking to url correction

added an endpoint for number of nodes in the database

added (well, connected) a CLI option for in-memory vs. not-in-memory index
