### PR TITLE
Mj/dockerhub

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,13 +1,18 @@
-# Github Actions Workflows
+# GitHub Actions Workflows
 
-This folder contains Github Actions workflows
+This folder contains GitHub Actions workflows.
 
-- `rust-ci.yml` uses cargo to run a build & test job 
-  - This automatically triggers on the following events:
+- `rust-ci.yml` uses Cargo to build and test the Rust project  
+  - This workflow automatically triggers on:
     1. Push to any branch (`**`)
-    2. Pull requests to `main` branch
-- `rust_container_publishing.yml` publishes container images to docker hub and ghcr (github container repo) with attestations
-  - This will automatically trigger on the following events:
-    1. Push to the 'main' branch (which should only happen with a merge)
-    2. Setting of tags on `main` with semver tags 
-    3. The Rust Build & Test (`rust-ci.yml`) job runs successfully
+    2. Pull requests targeting the `main` branch
+
+- `rust_container_publishing.yml` publishes Docker images to [Docker Hub](https://hub.docker.com/u/spicelabs) as `spicelabs/bigtent`  
+  - The image includes:
+    - Provenance attestations
+    - Software Bill of Materials (SBOM)
+    - Multi-format semver tags (e.g. `v1.2.3`, `v1.2`, `v1`)
+  - This workflow triggers automatically on:
+    1. Push of a semantic version tag (e.g. `v1.2.3`)
+    2. Manual invocation via the GitHub Actions UI
+

--- a/.github/workflows/rust_publish_images.yml
+++ b/.github/workflows/rust_publish_images.yml
@@ -62,10 +62,8 @@ jobs:
             type=semver,pattern={{major}}
             type=sha
             type=raw,value=sha-${{ github.sha }}
-          labels: |
-            org.opencontainers.image.title=bigtent
-            org.opencontainers.image.source=https://github.com/${{ github.repository }}
-            org.opencontainers.image.revision=${{ github.sha }}
+          flavor: |
+            latest=auto
 
       - name: Build and Push Docker image
         id: push

--- a/.github/workflows/rust_publish_images.yml
+++ b/.github/workflows/rust_publish_images.yml
@@ -1,4 +1,4 @@
-name: Publish Rust Container Images
+name: Publish Rust Container Image
 
 on:
   push:
@@ -17,13 +17,12 @@ jobs:
       - name: Check Cargo Version Matches Tag
         uses: spice-labs-inc/action-check-version@main
 
-  push_to_registry:
-    name: Push Docker image to Docker Hub and GHCR
+  push_to_dockerhub:
+    name: Push Docker Image to Docker Hub
     runs-on: ubuntu-24.04
     needs: check-version
 
     permissions:
-      packages: write
       contents: read
       attestations: write
       id-token: write
@@ -52,30 +51,19 @@ jobs:
           username: "${{ secrets.DOCKER_USERNAME }}"
           password: "${{ secrets.DOCKER_TOKEN }}"
 
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: "${{ github.actor }}"
-          password: "${{ secrets.GH_TOKEN }}"
-
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: |
-            ghcr.io/spice-labs-inc/${{ github.event.repository.name }}
-            spicelabs/${{ github.event.repository.name }}
+          images: spicelabs/bigtent
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha
             type=raw,value=sha-${{ github.sha }}
           labels: |
-            org.opencontainers.image.title=${{ env.IMAGE_NAME }}
+            org.opencontainers.image.title=bigtent
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
 
@@ -93,6 +81,6 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:
-          subject-name: ghcr.io/spice-labs-inc/${{ github.event.repository.name }}
+          subject-name: spicelabs/bigtent
           subject-digest: "${{ steps.push.outputs.digest }}"
           push-to-registry: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,7 +253,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bigtent"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bigtent"
-version = "0.10.4"
+version = "0.10.5"
 edition = "2024"
 authors = ["David Pollak <feeder.of.the.bears@gmail.com>"]
 rust-version = "1.85.0"


### PR DESCRIPTION
### Description of Change(s) (w/ context)

- Workflow now only publishes to Docker Hub

---
### Rationale Behind Change(s)

- Change in policy: Public repositories are now only published to Docker Hub

---
### Test Plan

  1. Create branch
  2. Update workflow
  3. Tested workflows and resolved errors then tested again until the workflows completed successfully

---
### Documentation

- What documentation did you add or update? README.md
- Added notation in Staging to Production doc

---
### Quality Control

(All items must be checked before a PR is merged)
- [ ] Mention an issue number in the PR title?
- [ ] Update the version # in the build file?
- [ ] Create new and/or update relevant existing tests?
- [ ] Create or update relevant documentation and/or diagrams?
- [ ] Comment your code?
- [ ] Fix any stray verbose logging (removing, or moving to debug / trace level)?

---
### Before Merging

- Make sure the Quality Control boxes are all ticked
- Make sure any open comments or conversations on the PR are resolved

---