### PR TITLE
Fixes #79.  Adjust build file to do arm as well

### DIFF
--- a/.github/workflows/rust_publish_images.yml
+++ b/.github/workflows/rust_publish_images.yml
@@ -1,5 +1,8 @@
 name: Publish Rust Container Image
 
+env:
+  PLATFORMS: linux/amd64, linux/arm64
+
 on:
   push:
     tags: [ 'v*.*.*' ]  # Trigger only on semantic version tags
@@ -28,8 +31,13 @@ jobs:
       id-token: write
 
     steps:
-      - name: Set up Docker Buildx
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+            platforms: ${{env.PLATFORMS}}
 
       - name: Checkout with LFS
         uses: actions/checkout@v4
@@ -69,6 +77,7 @@ jobs:
         id: push
         uses: docker/build-push-action@v6
         with:
+          platforms: ${{env.PLATFORMS}}
           context: .
           push: true
           provenance: mode=max


### PR DESCRIPTION
### 💻 Description of Change(s) (w/ context)
Adjusted github publish action to also build and push ARM container images

### 🧠 Rationale Behind Change(s)
Supporting both arm and amd64 is a commitment we've made for our open source.  Also for our own internal use, Mac devs are better supported with native images

### 📝 Test Plan
This is a challenge to test.  We have to test in production sadly.  I've done several readings and comparisons to our patterns that work.

### 📜 Documentation
None needed

### 💣 Quality Control
(All items must be checked before a PR is merged)
Did you…
- [X ] Mention an issue number in the PR title?
- [N/A ] Update the version # in the build file?
- [N/A ] Create new and/or update relevant existing tests?
- [N/A ] Create or update relevant documentation and/or diagrams?
- [X ] Comment your code?
- [N/A ] Fix any stray verbose logging (removing, or moving to debug / trace level)?

### Before Merging…
- Make sure the Quality Control boxes are all ticked
- Make sure any open comments or conversations on the PR are resolved
