### PR TITLE
Added 'identifier' query parameter which is URL encoded

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,35 @@ If you change the `config.toml` file, send a `SIGHUP` (`kill -HUP <big_tent_proc
 
 To create an OmniBOR Corpus, use [Goat Rodeo](https://github.com/spice-labs-inc/goatrodeo).
 
+
+## Endpoints
+
+The following are Big Tent's endpoints:
+
+* `POST /omnibor/bulk` -- POST an array of Strings to get the bulk `Item`s.
+* `GET /omnibor/{*gitoid}` or `GET /omnibor/?identifier=gitoid"` -- get a single `Item`. Note
+   in the URL form, the identifier (`{*gitoid}`) is _not_ URL encoded. This allows for
+   copy/pasting of Package URLs without any escaping.
+* `GET /omnibor/aa/{*gitoid}` or `GET /omnibor/aa/?identifier=gitoid"` -- get a single `Item`. If the
+  `Item` contains an `alias:to` in its connection, follow the alias.
+   In the URL form, the identifier (`{*gitoid}`) is _not_ URL encoded. This allows for
+   copy/pasting of Package URLs without any escaping.
+* `GET /omnibor/north/{*gitoid}` or `GET /omnibor/north/?identifier=gitoid"` -- get all the `Items` connected to
+  the found item via `build:up`, `alias:to`, and `contained:up`. This can be a large list.
+  In the URL form, the identifier (`{*gitoid}`) is _not_ URL encoded. This allows for
+  copy/pasting of Package URLs without any escaping.
+* `POST /omnibor/north` -- The POST body contains a JSON array of Strings that are the identifiers of the
+  root `Item`s.  Get all the `Items` connected to
+  the found/root items via `build:up`, `alias:to`, and `contained:up`. This can be a large list.
+  In the URL form, the identifier (`{*gitoid}`) is _not_ URL encoded. This allows for
+  copy/pasting of Package URLs without any escaping.
+* `GET /omnibor/north_purls/{*gitoid}` or `GET /omnibor/north_purls/?identifier=gitoid"` -- get all the `Items` connected to
+  the found item via `build:up`, `alias:to`, and `contained:up`. Return only the `alias:from` connections
+  In the URL form, the identifier (`{*gitoid}`) is _not_ URL encoded. This allows for
+  copy/pasting of Package URLs without any escaping.
+* `GET /purls` -- return all the Package URLs in the Artifact Dependency Graph.
+* `GET /node_count` -- return the count of all the nodes in the Artifact Dependency Graph.
+
 ## Design docs
 
 In the [info](info/README.md) directory.


### PR DESCRIPTION
## Description of Changes

The original design on Big Tent was to be "friendly" to package URLs. Specifically, `GET /omnibor/pkg:maven/zone.cogni.asquare/application-profile@0.6.17` was valid with no URL encoding of the package URL `pkg:maven/zone.cogni.asquare/application-profile@0.6.17`

This, it turns out, causes problems for `tags` which have text in them that must be URL encoded.

Thus, the option was added to do either `GET /omnibor/pkg:maven/zone.cogni.asquare/application-profile@0.6.17` or `GET /omnibor/?identifier=pkg%3Amaven%2Fzone.cogni.asquare%2Fapplication-profile%400.6.17`


## Documentation

Added endpoint documentation to README.

## Testing / Verification

Passes existing tests. Smoke tested the `identifier` query parameter.

Issue #88 
