### PR TITLE
Find roots, synthetic clusters, some refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,9 +120,9 @@ checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "async-compression"
-version = "0.4.25"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40f6024f3f856663b45fd0c9b6f2024034a702f453549449e0d84a305900dad4"
+checksum = "ddb939d66e4ae03cee6091612804ba446b12878410cfa17f785f4dd67d4014e8"
 dependencies = [
  "brotli",
  "flate2",
@@ -249,7 +249,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bigtent"
-version = "0.10.6"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -370,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.29"
+version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
+checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
 dependencies = [
  "jobserver",
  "libc",
@@ -401,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -411,9 +411,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -423,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -462,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -929,9 +929,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1093,9 +1093,9 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1188,9 +1188,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.4"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
+checksum = "360e552c93fa0e8152ab463bc4c4837fce76a225df11dfaeea66c313de5e61f7"
 dependencies = [
  "bitflags",
  "libc",
@@ -1250,9 +1250,9 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memmap2"
-version = "0.9.5"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+checksum = "483758ad303d734cec05e5c12b41d7e93e6a6390c5e9dae6bdeb7c1259012d28"
 dependencies = [
  "libc",
 ]
@@ -1460,9 +1460,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1529,9 +1529,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc_version"
@@ -1611,9 +1611,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "itoa",
  "memchr",
@@ -1702,12 +1702,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1843,9 +1843,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.46.1"
+version = "1.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
+checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1856,7 +1856,7 @@ dependencies = [
  "slab",
  "socket2",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2313,15 +2313,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -2335,7 +2326,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -2356,10 +2347,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bigtent"
-version = "0.10.6"
+version = "0.11.0"
 edition = "2024"
 authors = ["David Pollak <feeder.of.the.bears@gmail.com>"]
 rust-version = "1.85.0"

--- a/src/fresh_merge.rs
+++ b/src/fresh_merge.rs
@@ -18,9 +18,9 @@ use std::println as info;
 use crate::{
   item::Item,
   rodeo::{
-    goat::GoatRodeoCluster,
     goat_trait::GoatRodeoTrait,
     index::{HasHash, ItemOffset},
+    member::HerdMember,
     writer::ClusterWriter,
   },
   util::{MD5Hash, NiceDurationDisplay, iso8601_now},
@@ -29,7 +29,7 @@ use anyhow::Result;
 use thousands::Separable;
 
 pub async fn merge_fresh<PB: Into<PathBuf>>(
-  clusters: Vec<Arc<GoatRodeoCluster>>,
+  clusters: Vec<Arc<HerdMember>>,
   dest_directory: PB,
 ) -> Result<()> {
   let start = Instant::now();
@@ -409,7 +409,7 @@ fn test_merge() {
 }
 
 struct ClusterPos {
-  pub cluster: Arc<GoatRodeoCluster>,
+  pub cluster: Arc<HerdMember>,
   pub pos: usize,
   pub len: usize,
   pub cache: Option<ItemOffset>,
@@ -441,7 +441,7 @@ impl ClusterPos {
 
 fn next_hash_of_item_to_merge(
   index_holder: &mut Vec<ClusterPos>,
-) -> Option<Vec<(ItemOffset, Arc<GoatRodeoCluster>)>> {
+) -> Option<Vec<(ItemOffset, Arc<HerdMember>)>> {
   let mut lowest: Option<MD5Hash> = None;
   let mut low_clusters = vec![];
 

--- a/src/item.rs
+++ b/src/item.rs
@@ -297,6 +297,28 @@ impl From<&Item> for serde_json::Value {
 }
 
 impl Item {
+  /// is the item a "root" item... no "up" or "tag:from"
+  pub fn is_root_item(&self) -> bool {
+    if self.body_mime_type != Some("application/vnd.cc.goatrodeo".to_string()) {
+      return false;
+    }
+    if self.identifier == "tags" {
+      return false;
+    }
+
+    for v in &self.connections {
+      if v.0.is_alias_to() {
+        return false;
+      }
+      if v.0.is_contained_by_up() {
+        return false;
+      }
+      if v.0.is_tag_from() {
+        return true;
+      }
+    }
+    true
+  }
   /// Find all the aliases that are package URLs
   pub fn find_purls(&self) -> Vec<String> {
     self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,11 @@ pub mod rodeo {
   pub mod data;
   pub mod goat;
   pub mod goat_herd;
+  pub mod goat_synth;
   pub mod goat_trait;
   pub mod holder;
   pub mod index;
+  pub mod member;
   pub mod writer;
 }
 pub mod item;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,11 @@ use arc_swap::ArcSwap;
 use bigtent::{
   config::Args,
   fresh_merge::merge_fresh,
-  rodeo::{goat::GoatRodeoCluster, holder::ClusterHolder},
+  rodeo::{
+    goat::GoatRodeoCluster,
+    holder::ClusterHolder,
+    member::{HerdMember, member_core},
+  },
   server::run_web_server,
 };
 use clap::{CommandFactory, Parser};
@@ -56,10 +60,10 @@ async fn run_merge(paths: Vec<PathBuf>, args: Args) -> Result<()> {
   let start = Instant::now();
 
   info!("Loading clusters...");
-  let mut clusters: Vec<Arc<GoatRodeoCluster>> = vec![];
+  let mut clusters: Vec<Arc<HerdMember>> = vec![];
   for p in &paths {
     for b in GoatRodeoCluster::cluster_files_in_dir(p.clone(), false).await? {
-      clusters.push(b);
+      clusters.push(member_core(b));
     }
   }
   info!(

--- a/src/rodeo/goat.rs
+++ b/src/rodeo/goat.rs
@@ -17,14 +17,11 @@ use tokio_util::either::Either;
 use tokio::{
   fs::{File as TokioFile, read_dir},
   io::BufReader,
-  sync::{
-    Mutex,
-    mpsc::{Receiver, Sender},
-  },
+  sync::{Mutex, mpsc::Receiver},
 };
 
 use crate::{
-  item::{EdgeType, Item},
+  item::Item,
   util::{
     MD5Hash, byte_slice_to_u63, find_common_root_dir, hex_to_u64, is_child_dir, md5hash_str,
     read_len_and_cbor, read_u32, sha256_for_reader,
@@ -39,7 +36,7 @@ use std::println as info;
 use super::{
   cluster::{ClusterFileEnvelope, ClusterFileMagicNumber},
   data::{DataFile, GOAT_RODEO_CLUSTER_FILE_SUFFIX},
-  goat_trait::{GoatRodeoTrait, impl_north_send, impl_stream_flattened_items},
+  goat_trait::{GoatRodeoTrait, impl_antialias_for, impl_north_send, impl_stream_flattened_items},
   index::{GetOffset, IndexFile, ItemLoc, ItemOffset, find_item_offset},
 };
 
@@ -138,13 +135,12 @@ impl GoatRodeoTrait for GoatRodeoCluster {
   }
 
   async fn north_send(
-    &self,
+    self: Arc<GoatRodeoCluster>,
     gitoids: Vec<String>,
     purls_only: bool,
-    tx: Sender<Either<Item, String>>,
     start: Instant,
-  ) -> Result<()> {
-    impl_north_send(self, gitoids, purls_only, tx, start).await
+  ) -> Result<Receiver<Either<Item, String>>> {
+    impl_north_send(self, gitoids, purls_only, start).await
   }
 
   fn item_for_identifier(&self, data: &str) -> Result<Option<Item>> {
@@ -159,29 +155,8 @@ impl GoatRodeoTrait for GoatRodeoCluster {
     }
   }
 
-  fn antialias_for(&self, data: &str) -> Result<Option<Item>> {
-    let mut ret = match self.item_for_identifier(data)? {
-      Some(i) => i,
-      _ => return Ok(None),
-    };
-    while ret.is_alias() {
-      match ret.connections.iter().find(|x| x.0.is_alias_to()) {
-        Some(v) => {
-          ret = match self.item_for_identifier(&v.1)? {
-            Some(v) => v,
-            _ => bail!(
-              "Expecting to traverse from {}, but no aliases found",
-              ret.identifier
-            ),
-          };
-        }
-        None => {
-          bail!("Unexpected situation");
-        }
-      }
-    }
-
-    Ok(Some(ret))
+  fn antialias_for(self: Arc<Self>, data: &str) -> Result<Option<Item>> {
+    impl_antialias_for(self, data)
   }
 
   fn has_identifier(&self, identifier: &str) -> bool {
@@ -220,6 +195,25 @@ impl GoatRodeoTrait for GoatRodeoCluster {
       ret += io.len as u64;
     }
     ret
+  }
+
+  async fn roots(self: Arc<Self>) -> Receiver<Item> {
+    let (tx, rx) = tokio::sync::mpsc::channel(256);
+
+    let _ = tokio::spawn(async move {
+      for offset in 0..self.number_of_items {
+        if let Ok(item_offset) = self.offset_from_pos(offset) {
+          if let Ok(item) = self.item_from_item_offset(&item_offset) {
+            if item.is_root_item() {
+              let _ = tx.send(item).await;
+            }
+          }
+        }
+      }
+    })
+    .await;
+
+    rx
   }
 }
 
@@ -768,6 +762,7 @@ async fn test_antialias() {
   for ai in aliases.iter().take(20) {
     println!("Antialias for {}", ai.identifier);
     let new_item = cluster
+      .clone()
       .antialias_for(&ai.identifier)
       .expect("Expect to get the antialiased thing")
       .expect("And it's not a None");
@@ -911,6 +906,51 @@ async fn test_files_in_dir() {
     "must read at least 7,000 items, but only got {}",
     total_index_size
   );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 5)]
+async fn test_roots() {
+  let to_test = vec![
+    (
+      "test_data/cluster_a/2025_04_19_17_10_26_012a73d9c40dc9c0.grc",
+      1,
+    ),
+    (
+      "test_data/cluster_b/2025_04_19_17_10_40_09ebe9a7137ee100.grc",
+      1,
+    ),
+    (
+      "test_data/cluster_c/2025_07_24_14_43_36_68a489f4fd40c5e2.grc",
+      1,
+    ),
+    (
+      "test_data/cluster_d/2025_07_24_14_44_14_2b39577cd0a58701.grc",
+      5,
+    ),
+  ];
+  for (file, cnt) in to_test {
+    let path = PathBuf::from(file);
+    println!("Getting cluster {}", file);
+    let cluster = GoatRodeoCluster::new(&path.parent().unwrap().to_path_buf(), &path, false)
+      .await
+      .expect("Should get cluster");
+    println!("Goat cluster {}", file);
+    let mut rx = cluster.roots().await;
+    let mut info = vec![];
+    while let Some(item) = rx.recv().await {
+      info.push(item);
+    }
+    println!("Pushed {} items for {}", info.len(), file);
+
+    assert!(
+      info.len() == cnt,
+      "for {} expected {}, actual len {} and filenames {:?}",
+      file,
+      cnt,
+      info.len(),
+      info
+    );
+  }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/src/rodeo/goat_synth.rs
+++ b/src/rodeo/goat_synth.rs
@@ -1,0 +1,240 @@
+use std::{collections::BTreeSet, fmt::Debug, fs::File, io::Write, path::PathBuf, sync::Arc};
+
+use crate::{
+  item::{Item, TAG_FROM, TAG_TO},
+  rodeo::goat_trait::{impl_antialias_for, impl_north_send, impl_stream_flattened_items},
+  util::{MD5Hash, iso8601_now, md5hash_str, sha256_for_slice},
+};
+use anyhow::{Result, bail};
+use serde_json::{Map, json};
+use thousands::Separable;
+use tokio::sync::mpsc::Receiver;
+use tokio_util::either::Either;
+use uuid::Uuid;
+
+use super::{goat_trait::GoatRodeoTrait, index::ItemOffset};
+#[derive(Debug, Clone)]
+pub struct GoatSynth {
+  name: String,
+  items: Vec<Item>,
+  uuid: String,
+  offsets: Vec<ItemOffset>,
+  history: serde_json::Value,
+}
+
+impl GoatSynth {
+  pub fn name(&self) -> String {
+    self.name.clone()
+  }
+  pub fn offset_from_pos(&self, pos: usize) -> Result<ItemOffset> {
+    if pos >= self.items.len() {
+      bail!("Offset out of bounds {} vs. {}", pos, self.items.len());
+    }
+
+    Ok(self.offsets[pos])
+  }
+  pub fn item_from_item_offset(&self, item_offset: &ItemOffset) -> Result<Item> {
+    let pos = item_offset.loc.0;
+    if pos >= self.items.len() {
+      bail!("Invalid offset {}", pos);
+    }
+
+    Ok(self.items[pos].clone())
+  }
+  pub fn new(name: &str, items: Vec<Item>, history: serde_json::Value) -> Arc<GoatSynth> {
+    let uuid = Uuid::new_v4().to_string();
+    let mut offsets = vec![];
+    for (idx, item) in items.iter().enumerate() {
+      offsets.push(ItemOffset {
+        hash: md5hash_str(&item.identifier),
+        loc: (idx, 0),
+      });
+    }
+    offsets.sort_by_key(|v| v.hash);
+    Arc::new(GoatSynth {
+      name: name.to_string(),
+      items,
+      uuid,
+      offsets,
+      history,
+    })
+  }
+
+  pub fn new_tags(
+    tag_name: &str,
+    tags: Vec<(String, serde_json::Value)>,
+  ) -> Result<Arc<GoatSynth>> {
+    let mut items = vec![];
+    for (name, json) in tags {
+      let mut map = match json {
+        serde_json::Value::Object(m) => m,
+        v => {
+          let mut m = Map::new();
+          m.insert("extra".to_string(), v);
+          m
+        }
+      };
+      map.insert("tag".to_string(), tag_name.into());
+      map.insert("date".to_string(), iso8601_now().into());
+
+      let ser = serde_cbor::to_vec(&serde_json::Value::separate_with_spaces(
+        &serde_json::Value::Object(map),
+      ))?;
+
+      let identifier = hex::encode(&sha256_for_slice(&ser));
+
+      let body: serde_cbor::Value = serde_cbor::from_reader(&ser[..])?; // serde_cbor::Value::deserialize(deserializer)json.into();
+      let i = Item {
+        identifier,
+        connections: BTreeSet::from([
+          (TAG_FROM.to_string(), "tags".to_string()),
+          (TAG_TO.to_string(), name),
+        ]),
+        body_mime_type: Some("application/vnd.cc.goatrodeo.tag".to_string()),
+        body: Some(body),
+      };
+      items.push(i);
+    }
+    let mut connections = BTreeSet::new();
+    for i in &items {
+      connections.insert((TAG_TO.to_string(), i.identifier.to_string()));
+    }
+    let tags = Item {
+      identifier: "tags".to_string(),
+      connections,
+      body_mime_type: None,
+      body: None,
+    };
+    items.push(tags);
+
+    Ok(GoatSynth::new(
+      tag_name,
+      items,
+      json!({"date": iso8601_now(), "operation": "synthetic tag"}),
+    ))
+  }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test_synthetic() {
+  use super::{goat::GoatRodeoCluster, goat_herd::GoatHerd};
+  use crate::item::EdgeType;
+  let path = PathBuf::from("test_data/cluster_a/2025_04_19_17_10_26_012a73d9c40dc9c0.grc");
+  let cluster_a = GoatRodeoCluster::new(&path.parent().unwrap().to_path_buf(), &path, false)
+    .await
+    .expect("Should get first cluster");
+  let mut roots = cluster_a.clone().roots().await;
+  let mut root_ids = vec![];
+  while let Some(item) = roots.recv().await {
+    root_ids.push((item.identifier.clone(), json!({"hello": 42})));
+  }
+
+  let synth = GoatSynth::new_tags("test test", root_ids).expect("Should get a synthetic goat");
+
+  let herd = GoatHerd::new(vec![
+    crate::rodeo::member::member_core(cluster_a),
+    crate::rodeo::member::member_synth(synth),
+  ]);
+
+  let tags = herd
+    .item_for_identifier("tags")
+    .expect("Should get tags")
+    .expect("Should get tags from option");
+
+  let tagged: Vec<String> = tags
+    .connections
+    .iter()
+    .filter(|conn| conn.0.is_tag_to())
+    .map(|conn| conn.1.clone())
+    .collect();
+
+  assert_eq!(tagged.len(), 1, "Expecting 1 tag, got {:?}", tagged);
+}
+
+impl GoatRodeoTrait for GoatSynth {
+  fn node_count(&self) -> u64 {
+    self.items.len() as u64
+  }
+
+  fn get_purl(&self) -> Result<PathBuf> {
+    let filename = format!("/tmp/{}.txt", self.uuid);
+    let ret = PathBuf::from(&filename);
+    if ret.exists() && ret.is_file() {
+      return Ok(ret);
+    }
+
+    let mut dest = File::create(&ret)?;
+
+    dest.flush()?;
+    Ok(ret)
+  }
+
+  fn number_of_items(&self) -> usize {
+    self.items.len()
+  }
+
+  fn read_history(&self) -> Result<Vec<serde_json::Value>> {
+    Ok(vec![self.history.clone()])
+  }
+
+  async fn north_send(
+    self: Arc<Self>,
+    gitoids: Vec<String>,
+    purls_only: bool,
+    start: std::time::Instant,
+  ) -> Result<Receiver<Either<Item, String>>> {
+    impl_north_send(self, gitoids, purls_only, start).await
+  }
+
+  async fn roots(self: Arc<Self>) -> Receiver<Item> {
+    let (tx, rx) = tokio::sync::mpsc::channel(256);
+    let _ = tokio::spawn(async move {
+      for item in &self.items {
+        if item.is_root_item() {
+          let _ = tx.send(item.clone()).await;
+        }
+      }
+    })
+    .await;
+    rx
+  }
+
+  fn item_for_identifier(&self, data: &str) -> Result<Option<Item>> {
+    self.item_for_hash(md5hash_str(data))
+  }
+
+  fn item_for_hash(&self, hash: MD5Hash) -> Result<Option<Item>> {
+    let found = match self.offsets.binary_search_by_key(&hash, |v| v.hash) {
+      Ok(v) => v,
+      Err(_) => bail!("Key not found"),
+    };
+    let res = match self.item_from_item_offset(&self.offsets[found]) {
+      Ok(v) => Some(v),
+      Err(_) => None,
+    };
+    Ok(res)
+  }
+
+  fn antialias_for(self: Arc<Self>, data: &str) -> Result<Option<Item>> {
+    impl_antialias_for(self, data)
+  }
+
+  async fn stream_flattened_items(
+    self: Arc<Self>,
+    gitoids: Vec<String>,
+    source: bool,
+  ) -> Result<Receiver<Either<Item, String>>> {
+    impl_stream_flattened_items(self, gitoids, source).await
+  }
+
+  fn has_identifier(&self, identifier: &str) -> bool {
+    self
+      .offsets
+      .binary_search_by_key(&md5hash_str(identifier), |v| v.hash)
+      .is_ok()
+  }
+
+  fn is_empty(&self) -> bool {
+    self.items.is_empty()
+  }
+}

--- a/src/rodeo/member.rs
+++ b/src/rodeo/member.rs
@@ -1,0 +1,160 @@
+use crate::{item::Item, util::MD5Hash};
+
+use super::{
+  goat::GoatRodeoCluster, goat_synth::GoatSynth, goat_trait::GoatRodeoTrait, index::ItemOffset,
+};
+use anyhow::Result;
+use std::{path::PathBuf, sync::Arc};
+use tokio::sync::mpsc::Receiver;
+use tokio_util::either::Either;
+
+#[derive(Debug, Clone)]
+pub enum HerdMember {
+  Synth(Arc<GoatSynth>),
+  Core(Arc<GoatRodeoCluster>),
+}
+
+pub fn member_core(it: Arc<GoatRodeoCluster>) -> Arc<HerdMember> {
+  Arc::new(HerdMember::Core(it))
+}
+pub fn member_synth(it: Arc<GoatSynth>) -> Arc<HerdMember> {
+  Arc::new(HerdMember::Synth(it))
+}
+
+impl HerdMember {
+  pub fn name(&self) -> String {
+    match self {
+      HerdMember::Synth(goat_synth) => goat_synth.name(),
+      HerdMember::Core(goat_rodeo_cluster) => goat_rodeo_cluster.name(),
+    }
+  }
+
+  pub fn offset_from_pos(&self, pos: usize) -> Result<ItemOffset> {
+    match self {
+      HerdMember::Synth(goat_synth) => goat_synth.offset_from_pos(pos),
+      HerdMember::Core(goat_rodeo_cluster) => goat_rodeo_cluster.offset_from_pos(pos),
+    }
+  }
+
+  pub fn item_from_item_offset(&self, offset: &ItemOffset) -> Result<Item> {
+    match self {
+      HerdMember::Synth(goat_synth) => goat_synth.item_from_item_offset(offset),
+      HerdMember::Core(goat_rodeo_cluster) => goat_rodeo_cluster.item_from_item_offset(offset),
+    }
+  }
+}
+
+impl GoatRodeoTrait for HerdMember {
+  fn node_count(&self) -> u64 {
+    match self {
+      HerdMember::Synth(goat_synth) => goat_synth.node_count(),
+      HerdMember::Core(goat_rodeo_cluster) => goat_rodeo_cluster.node_count(),
+    }
+  }
+
+  fn get_purl(&self) -> Result<PathBuf> {
+    match self {
+      HerdMember::Synth(goat_synth) => goat_synth.get_purl(),
+      HerdMember::Core(goat_rodeo_cluster) => goat_rodeo_cluster.get_purl(),
+    }
+  }
+
+  fn number_of_items(&self) -> usize {
+    match self {
+      HerdMember::Synth(goat_synth) => goat_synth.number_of_items(),
+      HerdMember::Core(goat_rodeo_cluster) => goat_rodeo_cluster.number_of_items(),
+    }
+  }
+
+  fn read_history(&self) -> Result<Vec<serde_json::Value>> {
+    match self {
+      HerdMember::Synth(goat_synth) => goat_synth.read_history(),
+      HerdMember::Core(goat_rodeo_cluster) => goat_rodeo_cluster.read_history(),
+    }
+  }
+
+  async fn north_send(
+    self: Arc<Self>,
+    gitoids: Vec<String>,
+    purls_only: bool,
+    start: std::time::Instant,
+  ) -> Result<Receiver<Either<Item, String>>> {
+    match &*self {
+      HerdMember::Synth(goat_synth) => {
+        goat_synth
+          .clone()
+          .north_send(gitoids, purls_only, start)
+          .await
+      }
+      HerdMember::Core(goat_rodeo_cluster) => {
+        goat_rodeo_cluster
+          .clone()
+          .north_send(gitoids, purls_only, start)
+          .await
+      }
+    }
+  }
+
+  async fn roots(self: Arc<HerdMember>) -> Receiver<Item> {
+    match &*self {
+      HerdMember::Synth(goat_synth) => goat_synth.clone().roots().await,
+      HerdMember::Core(goat_rodeo_cluster) => goat_rodeo_cluster.clone().roots().await,
+    }
+  }
+
+  fn item_for_identifier(&self, data: &str) -> Result<Option<Item>> {
+    match self {
+      HerdMember::Synth(goat_synth) => goat_synth.item_for_identifier(data),
+      HerdMember::Core(goat_rodeo_cluster) => goat_rodeo_cluster.item_for_identifier(data),
+    }
+  }
+
+  fn item_for_hash(&self, hash: MD5Hash) -> Result<Option<Item>> {
+    match self {
+      HerdMember::Synth(goat_synth) => goat_synth.item_for_hash(hash),
+      HerdMember::Core(goat_rodeo_cluster) => goat_rodeo_cluster.item_for_hash(hash),
+    }
+  }
+
+  fn antialias_for(self: Arc<Self>, data: &str) -> Result<Option<Item>> {
+    match &*self {
+      HerdMember::Synth(goat_synth) => goat_synth.clone().antialias_for(data),
+      HerdMember::Core(goat_rodeo_cluster) => goat_rodeo_cluster.clone().antialias_for(data),
+    }
+  }
+
+  async fn stream_flattened_items(
+    self: Arc<Self>,
+    gitoids: Vec<String>,
+    source: bool,
+  ) -> Result<Receiver<Either<Item, String>>> {
+    match &*self {
+      HerdMember::Synth(goat_synth) => {
+        goat_synth
+          .clone()
+          .stream_flattened_items(gitoids, source)
+          .await
+      }
+      HerdMember::Core(goat_rodeo_cluster) => {
+        goat_rodeo_cluster
+          .clone()
+          .stream_flattened_items(gitoids, source)
+          .await
+      }
+    }
+  }
+
+  fn has_identifier(&self, identifier: &str) -> bool {
+    match self {
+      HerdMember::Synth(goat_synth) => goat_synth.has_identifier(identifier),
+      HerdMember::Core(goat_rodeo_cluster) => goat_rodeo_cluster.has_identifier(identifier),
+    }
+  }
+
+  fn is_empty(&self) -> bool {
+    match self {
+      HerdMember::Synth(goat_synth) => goat_synth.is_empty(),
+      HerdMember::Core(goat_rodeo_cluster) => goat_rodeo_cluster.is_empty(),
+    }
+  }
+}


### PR DESCRIPTION
## Description of Changes

Added synthetic clusters. This allows the creation of dynamic clusters. Useful to add tags to clusters even if the tags were not added by goat rodeo.

The ability to find "root" items in a cluster. This is an *expensive* `O(n)` operation that finds all the `Item`s that are not contained, builds to, etc. These are likely the actual top level files in a Goat Rodeo run.

Added tests especially around herds (a cluster made up of clusters) related to tags... if 5 clusters in a herd have tags, are the tags seen as coming from the single root `tags` `Item`?

## Testing / Verification

Added unit tests
---

## A Few Additional Things to Check

API changes, so updated to version `0.11.0`