### PR TITLE
Support for a root name of a robo cluster of than tags

### DIFF
--- a/src/rodeo/robo_goat.rs
+++ b/src/rodeo/robo_goat.rs
@@ -69,7 +69,7 @@ impl RoboticGoat {
   }
 
   /// Create a robo cluster with a base name (e.g., "tags" or "uploads")
-  /// where the tag name is particular string and the specific items are a
+  /// where the tag name is a particular string and the specific items are a
   /// `Vec<(String, Value)>`
   pub fn new_cluster(
     base_name: &str,


### PR DESCRIPTION
## Description of Changes
Renamed the `new_tags` function to `new_cluster` because the robo cluster can have a different root than `tags`


## Documentation

Wrote Rust docs

## Testing / Verification

updated unit test