### PR TITLE
Simplified the API by changing Result<Option<T>> to Option<T>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -88,29 +88,29 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
 name = "arc-swap"
@@ -249,7 +249,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bigtent"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -338,9 +338,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "camino"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da45bc31171d8d6960122e222a67740df867c1dd53b4d51caa297084c185cab"
+checksum = "5d07aa9a93b00c76f71bc35d598bed923f6d4f3a9ca5c24b7737ae1a292841c0"
 dependencies = [
  "serde",
 ]
@@ -370,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.30"
+version = "1.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
+checksum = "2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e"
 dependencies = [
  "jobserver",
  "libc",
@@ -401,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.41"
+version = "4.5.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -411,9 +411,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.41"
+version = "4.5.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -423,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.41"
+version = "4.5.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
+checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -834,9 +834,9 @@ checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "heck"
@@ -1170,9 +1170,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libgit2-sys"
@@ -1188,9 +1188,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360e552c93fa0e8152ab463bc4c4837fce76a225df11dfaeea66c313de5e61f7"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
  "bitflags",
  "libc",
@@ -1436,9 +1436,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1"
 dependencies = [
  "unicode-ident",
 ]
@@ -1489,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
@@ -1544,9 +1544,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -1611,9 +1611,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.141"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "itoa",
  "memchr",
@@ -1681,18 +1681,18 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -1733,9 +1733,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "7bc3fcb250e53458e712715cf74285c1f889686520d79294a9ef3bd7aa1fc619"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1774,18 +1774,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "0b0949c3a6c842cbde3f1686d6eea5a010516deb7085f79db747562d4102f41e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "cc5b44b4ab9c2fdd0e0512e6bece8388e214c0749f5862b114cc5b7a25daf227"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1843,9 +1843,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.47.0"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1883,9 +1883,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2040,9 +2040,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
 dependencies = [
  "getrandom 0.3.3",
  "js-sys",
@@ -2551,9 +2551,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke",
  "zerofrom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bigtent"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 authors = ["David Pollak <feeder.of.the.bears@gmail.com>"]
 rust-version = "1.85.0"

--- a/src/fresh_merge.rs
+++ b/src/fresh_merge.rs
@@ -424,7 +424,7 @@ impl ClusterPos {
       match &self.cache {
         Some(v) => Some(v.clone()),
         None => match self.cluster.offset_from_pos(self.pos) {
-          Ok(v) => {
+          Some(v) => {
             self.cache = Some(v.clone());
             Some(v)
           }

--- a/src/rodeo/goat_herd.rs
+++ b/src/rodeo/goat_herd.rs
@@ -85,10 +85,10 @@ impl GoatRodeoTrait for GoatHerd {
     impl_north_send(self, gitoids, purls_only, start).await
   }
 
-  fn item_for_identifier(&self, data: &str) -> Result<Option<Item>> {
+  fn item_for_identifier(&self, data: &str) -> Option<Item> {
     let mut items = vec![];
     for grc in &self.herd {
-      match grc.item_for_identifier(data)? {
+      match grc.item_for_identifier(data) {
         None => {}
         Some(item) => {
           items.push(item);
@@ -96,13 +96,13 @@ impl GoatRodeoTrait for GoatHerd {
       }
     }
 
-    Ok(Item::merge_items(items))
+    Item::merge_items(items)
   }
 
-  fn item_for_hash(&self, hash: crate::util::MD5Hash) -> Result<Option<Item>> {
+  fn item_for_hash(&self, hash: crate::util::MD5Hash) -> Option<Item> {
     let mut items = vec![];
     for grc in &self.herd {
-      match grc.item_for_hash(hash)? {
+      match grc.item_for_hash(hash) {
         None => {}
         Some(item) => {
           items.push(item);
@@ -110,10 +110,10 @@ impl GoatRodeoTrait for GoatHerd {
       }
     }
 
-    Ok(Item::merge_items(items))
+    Item::merge_items(items)
   }
 
-  fn antialias_for(self: Arc<Self>, data: &str) -> Result<Option<Item>> {
+  fn antialias_for(self: Arc<Self>, data: &str) -> Option<Item> {
     impl_antialias_for(self, data)
   }
 
@@ -228,7 +228,6 @@ async fn test_purls_and_merge() {
 
   let tags = herd2
     .item_for_identifier("tags")
-    .expect("Should get tags")
     .expect("Should get tags from option");
   let tagged: Vec<String> = tags
     .connections

--- a/src/rodeo/member.rs
+++ b/src/rodeo/member.rs
@@ -32,14 +32,14 @@ impl ClusterRoboMember for HerdMember {
     }
   }
 
-  fn offset_from_pos(&self, pos: usize) -> Result<ItemOffset> {
+  fn offset_from_pos(&self, pos: usize) -> Option<ItemOffset> {
     match self {
       HerdMember::Robo(goat_synth) => goat_synth.offset_from_pos(pos),
       HerdMember::Cluster(goat_rodeo_cluster) => goat_rodeo_cluster.offset_from_pos(pos),
     }
   }
 
-  fn item_from_item_offset(&self, offset: &ItemOffset) -> Result<Item> {
+  fn item_from_item_offset(&self, offset: &ItemOffset) -> Option<Item> {
     match self {
       HerdMember::Robo(goat_synth) => goat_synth.item_from_item_offset(offset),
       HerdMember::Cluster(goat_rodeo_cluster) => goat_rodeo_cluster.item_from_item_offset(offset),
@@ -105,21 +105,21 @@ impl GoatRodeoTrait for HerdMember {
     }
   }
 
-  fn item_for_identifier(&self, data: &str) -> Result<Option<Item>> {
+  fn item_for_identifier(&self, data: &str) -> Option<Item> {
     match self {
       HerdMember::Robo(goat_synth) => goat_synth.item_for_identifier(data),
       HerdMember::Cluster(goat_rodeo_cluster) => goat_rodeo_cluster.item_for_identifier(data),
     }
   }
 
-  fn item_for_hash(&self, hash: MD5Hash) -> Result<Option<Item>> {
+  fn item_for_hash(&self, hash: MD5Hash) -> Option<Item> {
     match self {
       HerdMember::Robo(goat_synth) => goat_synth.item_for_hash(hash),
       HerdMember::Cluster(goat_rodeo_cluster) => goat_rodeo_cluster.item_for_hash(hash),
     }
   }
 
-  fn antialias_for(self: Arc<Self>, data: &str) -> Result<Option<Item>> {
+  fn antialias_for(self: Arc<Self>, data: &str) -> Option<Item> {
     match &*self {
       HerdMember::Robo(goat_synth) => goat_synth.clone().antialias_for(data),
       HerdMember::Cluster(goat_rodeo_cluster) => goat_rodeo_cluster.clone().antialias_for(data),

--- a/src/server.rs
+++ b/src/server.rs
@@ -36,7 +36,7 @@ async fn stream_items<GRT: GoatRodeoTrait + 'static>(
   tokio::spawn(async move {
     for item_id in items {
       match rodeo.get_cluster().item_for_identifier(&item_id) {
-        Ok(Some(i)) => {
+        Some(i) => {
           if !mtx.is_closed() {
             let _ = mtx.send(i).await;
           }
@@ -125,7 +125,7 @@ async fn serve_gitoid<GRT: GoatRodeoTrait + 'static>(
   let ret = rodeo.get_cluster().item_for_identifier(&to_find);
 
   match ret {
-    Ok(Some(item)) => Ok(Json(item.to_json())),
+    Some(item) => Ok(Json(item.to_json())),
     _ => Err((
       StatusCode::NOT_FOUND,
       format!("No item found for key {}", to_find),
@@ -143,7 +143,7 @@ async fn serve_anti_alias<GRT: GoatRodeoTrait + 'static>(
   let ret = rodeo.get_cluster().antialias_for(&to_find);
 
   match ret {
-    Ok(Some(item)) => Ok(Json(item.to_json())),
+    Some(item) => Ok(Json(item.to_json())),
     _ => Err((
       StatusCode::NOT_FOUND,
       format!("No item found for key {}", to_find),


### PR DESCRIPTION
It turns out the `bail!` from a method when the answer should have been `return Ok(None)` caused cascading failures.

The pattern has been simplified.
