### PR TITLE
Updated meaning of north

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,7 +255,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bigtent"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,9 +387,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "chrono"
@@ -1782,18 +1782,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.15"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d76d3f064b981389ecb4b6b7f45a0bf9fdac1d5b9204c7bd6714fecc302850"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.15"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d29feb33e986b6ea906bd9c3559a856983f92371b3eaa5e83782a351623de0"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bigtent"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2024"
 authors = ["David Pollak <feeder.of.the.bears@gmail.com>"]
 rust-version = "1.86.0"

--- a/src/item.rs
+++ b/src/item.rs
@@ -340,11 +340,11 @@ impl Item {
   //   self.reference = Item::NOOP;
   // }
 
-  /// get all the connections that are either `contained_by_up` or `is_to_right`
+  /// get all the connections that are either `contained_by_up` or `is_alias_to` or `is_tag_from`
   pub fn contained_by(&self) -> HashSet<String> {
     let mut ret = HashSet::new();
     for edge in self.connections.iter() {
-      if edge.0.is_to() || edge.0.is_up() {
+      if edge.0.is_alias_to() || edge.0.is_tag_from() || edge.0.is_up() {
         ret.insert(edge.1.clone());
       }
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -85,7 +85,7 @@ async fn serve_bulk<GRT: GoatRodeoTrait + 'static>(
 
 /// compute the package from either uri which will include query parameters (which are part of)
 /// a pURL or the path that was passed in
-fn compute_package(query: &HashMap<String, String>, maybe_gitoid: &str, uri: &Uri) -> String {
+pub fn compute_package(query: &HashMap<String, String>, maybe_gitoid: &str, uri: &Uri) -> String {
   if maybe_gitoid.len() == uri.path().len() || maybe_gitoid.len() == uri.path().len() - 1 {
     if let Some(value) = query.get("identifier") {
       return value.clone();


### PR DESCRIPTION
Previously, `north` from a tag would traverse the tag's contents rather than treating the tag as terminal. This is fixed.

Updated the latest versions in `Cargo.toml`

Made the `compute_package` function public.
