### PR TITLE
Mj/cli scan

### DIFF
--- a/.github/workflows/rust_publish_images.yml
+++ b/.github/workflows/rust_publish_images.yml
@@ -5,27 +5,26 @@ env:
 
 on:
   push:
-    tags: [ 'v*.*.*' ]  # Still supports tagged runs
-  workflow_dispatch: {}  # Manual trigger for testing
+    tags: [ 'v*.*.*' ]
+  workflow_dispatch: {}
 
 jobs:
   check-version:
     name: Ensure GitHub Release & Cargo.toml Version Numbers Match
-    # Runs on tag pushes; will be skipped on manual runs that aren't tags
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-24.04
-
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Check Cargo Version Matches Tag
         uses: spice-labs-inc/action-check-version@main
 
   build_and_scan:
-    name: Build, Export OCI tar, Then Scan & Upload ADGs
+    name: Build, Export OCI tar, Conditionally Upload ADGs
     runs-on: ubuntu-24.04
-    needs: [check-version]
 
     permissions:
       contents: read
@@ -33,6 +32,12 @@ jobs:
       id-token: write
 
     steps:
+      - name: Checkout with full history (needed for branch check)
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+          fetch-depth: 0
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -40,11 +45,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           platforms: ${{ env.PLATFORMS }}
-
-      - name: Checkout with LFS
-        uses: actions/checkout@v4
-        with:
-          lfs: true
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -55,7 +55,7 @@ jobs:
       - name: Build project (Rust)
         run: cargo build --release
 
-      - name: Determine build tag for artifacts
+      - name: Compute build tag
         id: tag
         shell: bash
         run: |
@@ -69,37 +69,47 @@ jobs:
       - name: Prepare artifact directories
         run: mkdir -p artifacts/docker
 
-      # Build but DO NOT PUSH: export as an OCI tar we can scan
       - name: Build Docker image to OCI tar (no push)
         uses: docker/build-push-action@v6
         with:
           platforms: ${{ env.PLATFORMS }}
           context: .
           push: false
-          # Optional: annotate the image with a local tag (useful metadata)
           tags: spicelabs/bigtent:${{ steps.tag.outputs.tag }}
-          # Export an OCI layout tar for scanning
           outputs: type=oci,dest=artifacts/docker/bigtent-${{ steps.tag.outputs.tag }}.oci.tar
 
-      # Optional Maven build: only if this repo has a pom.xml
+      # Optional Maven build: local only
       - name: Build with Maven if pom.xml present
         if: hashFiles('pom.xml') != ''
         run: mvn -B -ntp -DskipTests package
 
-      # Scan & upload ADG for the Docker image tar
+      # ---- Branch gate: only upload when commit is on main ----
+      - name: Determine if commit is on main
+        id: branch_guard
+        shell: bash
+        run: |
+          git fetch --no-tags --prune origin +refs/heads/main:refs/remotes/origin/main
+          COMMIT="${GITHUB_SHA}"
+          if git merge-base --is-ancestor "$COMMIT" origin/main; then
+            echo "is_main=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_main=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Commit $COMMIT on main? ${{ steps.branch_guard.outputs.is_main }}"
+
+      # Upload only when commit is on main
       - name: Scan & upload ADG (Docker OCI tar)
+        if: steps.branch_guard.outputs.is_main == 'true'
         uses: spice-labs-inc/action-spice-labs-cli-scan@v3
         with:
           file_path: artifacts/docker
           spice_pass: ${{ secrets.SPICE_PASS }}
           tag: docker-${{ steps.tag.outputs.tag }}
 
-      # Scan & upload ADG for Maven build output (if any)
       - name: Scan & upload ADG (Maven target/)
-        if: hashFiles('pom.xml') != ''
+        if: steps.branch_guard.outputs.is_main == 'true' && hashFiles('pom.xml') != ''
         uses: spice-labs-inc/action-spice-labs-cli-scan@v3
         with:
           file_path: target
           spice_pass: ${{ secrets.SPICE_PASS }}
           tag: maven-${{ steps.tag.outputs.tag }}
-

--- a/.github/workflows/rust_publish_images.yml
+++ b/.github/workflows/rust_publish_images.yml
@@ -6,6 +6,7 @@ env:
 on:
   push:
     tags: [ 'v*.*.*' ]  # Trigger only on semantic version tags
+  workflow_dispatch: {}  # Manual trigger for testing
 
 jobs:
   check-version:

--- a/.github/workflows/rust_publish_images.yml
+++ b/.github/workflows/rust_publish_images.yml
@@ -1,16 +1,17 @@
-name: Publish Rust Container Image
+name: Publish Rust Container Image (Test)
 
 env:
-  PLATFORMS: linux/amd64, linux/arm64
+  PLATFORMS: linux/amd64,linux/arm64
 
 on:
   push:
-    tags: [ 'v*.*.*' ]  # Trigger only on semantic version tags
+    tags: [ 'v*.*.*' ]  # Still supports tagged runs
   workflow_dispatch: {}  # Manual trigger for testing
 
 jobs:
   check-version:
     name: Ensure GitHub Release & Cargo.toml Version Numbers Match
+    # Runs on tag pushes; will be skipped on manual runs that aren't tags
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-24.04
 
@@ -21,10 +22,10 @@ jobs:
       - name: Check Cargo Version Matches Tag
         uses: spice-labs-inc/action-check-version@main
 
-  push_to_dockerhub:
-    name: Push Docker Image to Docker Hub
+  build_and_scan:
+    name: Build, Export OCI tar, Then Scan & Upload ADGs
     runs-on: ubuntu-24.04
-    needs: check-version
+    needs: [check-version]
 
     permissions:
       contents: read
@@ -38,7 +39,7 @@ jobs:
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-            platforms: ${{env.PLATFORMS}}
+          platforms: ${{ env.PLATFORMS }}
 
       - name: Checkout with LFS
         uses: actions/checkout@v4
@@ -51,37 +52,54 @@ jobs:
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@v2
 
-      - name: Build project
+      - name: Build project (Rust)
         run: cargo build --release
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: "${{ secrets.DOCKER_USERNAME }}"
-          password: "${{ secrets.DOCKER_TOKEN }}"
+      - name: Determine build tag for artifacts
+        id: tag
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            TAG="${GITHUB_REF_NAME}"
+          else
+            TAG="test-${GITHUB_SHA::7}"
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: spicelabs/bigtent
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha
-            type=raw,value=sha-${{ github.sha }}
-          flavor: |
-            latest=auto
+      - name: Prepare artifact directories
+        run: mkdir -p artifacts/docker
 
-      - name: Build and Push Docker image
-        id: push
+      # Build but DO NOT PUSH: export as an OCI tar we can scan
+      - name: Build Docker image to OCI tar (no push)
         uses: docker/build-push-action@v6
         with:
-          platforms: ${{env.PLATFORMS}}
+          platforms: ${{ env.PLATFORMS }}
           context: .
-          push: true
-          provenance: mode=max
-          sbom: true
-          tags: "${{ steps.meta.outputs.tags }}"
-          labels: "${{ steps.meta.outputs.labels }}"
+          push: false
+          # Optional: annotate the image with a local tag (useful metadata)
+          tags: spicelabs/bigtent:${{ steps.tag.outputs.tag }}
+          # Export an OCI layout tar for scanning
+          outputs: type=oci,dest=artifacts/docker/bigtent-${{ steps.tag.outputs.tag }}.oci.tar
+
+      # Optional Maven build: only if this repo has a pom.xml
+      - name: Build with Maven if pom.xml present
+        if: hashFiles('pom.xml') != ''
+        run: mvn -B -ntp -DskipTests package
+
+      # Scan & upload ADG for the Docker image tar
+      - name: Scan & upload ADG (Docker OCI tar)
+        uses: spice-labs-inc/action-spice-labs-cli-scan@v3
+        with:
+          file_path: artifacts/docker
+          spice_pass: ${{ secrets.SPICE_PASS }}
+          tag: docker-${{ steps.tag.outputs.tag }}
+
+      # Scan & upload ADG for Maven build output (if any)
+      - name: Scan & upload ADG (Maven target/)
+        if: hashFiles('pom.xml') != ''
+        uses: spice-labs-inc/action-spice-labs-cli-scan@v3
+        with:
+          file_path: target
+          spice_pass: ${{ secrets.SPICE_PASS }}
+          tag: maven-${{ steps.tag.outputs.tag }}
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,7 +255,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bigtent"
-version = "0.12.3"
+version = "0.10.7"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bigtent"
-version = "0.12.3"
+version = "0.10.7"
 edition = "2024"
 authors = ["David Pollak <feeder.of.the.bears@gmail.com>"]
 rust-version = "1.86.0"


### PR DESCRIPTION
- Add manual trigger `workflow_dispatch: {}` for testing purposes
- Add checks for publishing to registry 
  - only published when released from main with Semantic Versioning