### PR TITLE
add ADG scan via reusable action

### DIFF
--- a/.github/workflows/rust_publish_images.yml
+++ b/.github/workflows/rust_publish_images.yml
@@ -84,3 +84,10 @@ jobs:
           sbom: true
           tags: "${{ steps.meta.outputs.tags }}"
           labels: "${{ steps.meta.outputs.labels }}"
+
+      - name: Index and upload ADG
+        uses: spice-labs-inc/action-spice-labs-cli-scan@v3
+        with:
+          token: ${{ secrets.SPICE_PASS }}
+          input: target
+          tag: ${{ github.event.repository.name }}


### PR DESCRIPTION
Adds a single step to index and upload ADGs using spice-labs-inc/action-spice-labs-cli-scan@v3.
