### PR TITLE
Mj/corrections

### DIFF
--- a/.github/workflows/rust_publish_images.yml
+++ b/.github/workflows/rust_publish_images.yml
@@ -88,6 +88,6 @@ jobs:
       - name: Index and upload ADG
         uses: spice-labs-inc/action-spice-labs-cli-scan@v3
         with:
-          token: ${{ secrets.SPICE_PASS }}
-          input: target
-          tag: ${{ github.event.repository.name }}
+          spice_pass: "${{ secrets.SPICE_PASS }}"
+          file_path: "./target"
+          tag: "${{ github.event.repository.name }}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,7 +255,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bigtent"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bigtent"
-version = "0.12.4"
+version = "0.12.5"
 edition = "2024"
 authors = ["David Pollak <feeder.of.the.bears@gmail.com>"]
 rust-version = "1.86.0"


### PR DESCRIPTION
Adds a single step to index and upload ADGs using spice-labs-inc/action-spice-labs-cli-scan@v3.

**Testing**

1. Create a release (e.g., tag vX.Y.Z).
2. Confirm GitHub Packages/Docker Hub and Maven Central publishing proceed as before.
3. Verify the new “Index and upload ADG” step runs and uploads ADGs to Spice Labs.
  - Link to successful run: https://github.com/spice-labs-inc/goatrodeo/actions/runs/17848354560
  - Screenshots of upload & dashboard