### PR TITLE
Fix binary search underflow corner case

### DIFF
--- a/src/rodeo/goat.rs
+++ b/src/rodeo/goat.rs
@@ -697,7 +697,8 @@ impl GoatRodeoCluster {
         match entry.hash.cmp(&hash) {
           Ordering::Less => low = mid + 1,
           Ordering::Equal => return Some(entry.clone()),
-          Ordering::Greater => hi = mid - 1,
+          Ordering::Greater if mid != 0 => hi = mid - 1,
+	  Ordering::Greater /* mid == 0 */ => return None,
         }
       }
 


### PR DESCRIPTION
### Summary

Sometimes a binary search would select index `0` as the mid-point and underflow the lower bound.  A search miss on index `0` indicates that the element wasn't found in the collection and thus we should return `None`