### PR TITLE
Cleanups, consistency in filename formation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,10 +87,8 @@ tempfile = "3"
 criterion = "0.5"
 
 [features]
-
-longtest = [] # feature has no explicit dependencies
-
-
+longtest = []
+extra_progress = []
 
 [build-dependencies]
 # All features enabled

--- a/benches/data_generator.rs
+++ b/benches/data_generator.rs
@@ -128,7 +128,7 @@ fn parse_args() -> Result<Args> {
                     anyhow::bail!("--overlap requires a value");
                 }
                 overlap = args[i + 1].parse()?;
-                if overlap < 0.0 || overlap > 100.0 {
+                if (0.0..=100.0).contains(&overlap) {
                     anyhow::bail!("--overlap must be between 0 and 100");
                 }
                 i += 2;

--- a/src/bench_util.rs
+++ b/src/bench_util.rs
@@ -7,7 +7,7 @@ use crate::item::{CONTAINED_BY, CONTAINS, Item};
 use crate::rodeo::goat_trait::GoatRodeoTrait;
 use crate::rodeo::robo_goat::{ClusterRoboMember, RoboticGoat};
 use crate::rodeo::writer::ClusterWriter;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use rand::Rng;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
@@ -181,9 +181,8 @@ pub async fn write_cluster_to_disk(
 
     // Write history
     let history_file = cluster_file
-        .canonicalize()?
         .parent()
-        .expect("Should have cluster parent dir")
+        .with_context(|| "Expected cluster_file {cluster_file:?} to have a parent directory")?
         .join("history.jsonl");
 
     let history = cluster.read_history()?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -156,8 +156,7 @@ impl Args {
             .iter()
             .flat_map(|host_name| {
                 let ma = format!("{}:{}", host_name, the_port);
-                let addr = ma.to_socket_addrs().ok();
-                addr
+                ma.to_socket_addrs().ok()
             })
             .flatten()
             .collect();

--- a/src/fresh_merge.rs
+++ b/src/fresh_merge.rs
@@ -232,11 +232,12 @@ pub async fn merge_fresh<PB: Into<PathBuf>>(
     // 20 threads fetch items from clusters and merge them
     // Channel for workers -> main thread: sends merged items
     let (merged_tx, merged_rx) = flume::bounded(200_000);
-    for thread_num in 0..20 {
+    for _thread_num in 0..20 {
         let rx = offset_rx.clone();
         let tx = merged_tx.clone();
 
         let processor_handle = thread::spawn(move || {
+            #[cfg(feature = "extra_progress")]
             let mut cnt = 0usize;
             while let Ok((position, items_to_merge)) = rx.recv() {
                 let mut to_merge = vec![];
@@ -274,13 +275,16 @@ pub async fn merge_fresh<PB: Into<PathBuf>>(
                     purls,
                 })
                 .expect("Should send message");
-                cnt += 1;
-                if false && cnt % 500_000 == 0 {
-                    info!(
-                        "Thread {} at cnt {}",
-                        thread_num,
-                        cnt.separate_with_commas()
-                    );
+                #[cfg(feature = "extra_progress")]
+                {
+                    cnt += 1;
+                    if cnt % 500_000 == 0 {
+                        info!(
+                            "Thread {} at cnt {}",
+                            thread_num,
+                            cnt.separate_with_commas()
+                        );
+                    }
                 }
             }
         });

--- a/src/fresh_merge.rs
+++ b/src/fresh_merge.rs
@@ -427,12 +427,7 @@ pub async fn merge_fresh<PB: Into<PathBuf>>(
 
     history.push(last_json);
 
-    let history_file = cluster_file
-        .canonicalize()
-        .with_context(|| format!("Could not canonicalize {:?}", cluster_file))?
-        .parent()
-        .with_context(|| format!("Cluster {:?} should have cluster parent dir", cluster_file))?
-        .join("history.jsonl");
+    let history_file = cluster_file.with_file_name("history.jsonl");
 
     write_json_lines(&history_file, &history)
         .with_context(|| format!("Failed writing json to {:?}", history_file))?;

--- a/src/item.rs
+++ b/src/item.rs
@@ -114,7 +114,7 @@ fn merge_values<F: Fn() -> Vec<String>, F2: Fn() -> Vec<String>>(
     fn fix_uno(s: &Value) -> Vec<String> {
         match s {
             Value::Text(s) => vec![s.clone()],
-            Value::Array(value_vec) => value_vec.iter().flat_map(|v| fix_uno(v)).collect(),
+            Value::Array(value_vec) => value_vec.iter().flat_map(fix_uno).collect(),
             _ => vec![],
         }
     }
@@ -154,13 +154,11 @@ fn merge_values<F: Fn() -> Vec<String>, F2: Fn() -> Vec<String>>(
                         let clean_merge: BTreeSet<Value> =
                             match (merged_file_names.len(), names.len(), v2_names.len()) {
                                 // if there's only one filename, then it's a clean merge
-                                (1, _, _) => {
-                                    merged_file_names.into_iter().map(|v| v.clone()).collect()
-                                }
+                                (1, _, _) => merged_file_names.into_iter().cloned().collect(),
 
                                 // if both have already done the filename to gitoid mapping, then it's safe to merge
                                 (_, tsize, osize) if tsize > 1 && osize > 1 => {
-                                    merged_file_names.into_iter().map(|v| v.clone()).collect()
+                                    merged_file_names.into_iter().cloned().collect()
                                 }
 
                                 // create the mapping
@@ -231,7 +229,7 @@ fn test_merge() {
     let merged_key = match merge1 {
         Value::Map(map) => {
             let m2 = map.clone();
-            m2.get(&foo).map(|v| v.clone())
+            m2.get(&foo).cloned()
         }
         _ => None,
     };
@@ -471,12 +469,9 @@ impl Item {
 
     pub fn to_json(&self) -> serde_json::Value {
         let mut ret = serde_json::to_value(self).expect("Should be able to serialize Item");
-        match ret {
-            serde_json::Value::Object(mut m) => {
-                m.remove_entry("reference");
-                ret = serde_json::Value::Object(m)
-            }
-            _ => {}
+        if let serde_json::Value::Object(mut m) = ret {
+            m.remove_entry("reference");
+            ret = serde_json::Value::Object(m)
         }
         ret
     }
@@ -504,7 +499,7 @@ impl Item {
 
     // merge to `Item`s
     pub fn merge(&self, other: Item) -> Item {
-        let (body, mime_type) = match (
+        let (body, body_mime_type) = match (
             &self.body,
             other.body.clone(),
             self.body_mime_type == other.body_mime_type,
@@ -513,12 +508,12 @@ impl Item {
             (None, Some(a), _) => (Some(a), other.body_mime_type.clone()),
             (Some(a), None, _) => (Some(a.clone()), self.body_mime_type.clone()),
             (Some(a), Some(b), true)
-                if self.body_mime_type.iter().map(|mt| mt as &str).last()
+                if self.body_mime_type.iter().map(|mt| mt as &str).next_back()
                     == Some(ITEM_METADATA_MIME_TYPE) =>
             {
                 match (from_value(a.clone()), from_value(b.clone())) {
                     (Ok::<ItemMetaData, _>(ai), Ok::<ItemMetaData, _>(bi)) => {
-                        let merged = ai.merge(bi, &self, &other);
+                        let merged = ai.merge(bi, self, &other);
                         (to_value(merged).ok(), self.body_mime_type.clone())
                     }
 
@@ -565,8 +560,8 @@ impl Item {
                 it.extend(other.connections);
                 it
             },
-            body_mime_type: mime_type,
-            body: body,
+            body_mime_type,
+            body,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,15 +63,11 @@ use bigtent::{
     server::run_web_server,
 };
 use clap::{CommandFactory, Parser};
+use opentelemetry::trace::TracerProvider;
+use opentelemetry_sdk::trace::SdkTracerProvider;
 #[cfg(not(test))]
-use {
-    opentelemetry::trace::TracerProvider,
-    opentelemetry_sdk::trace::SdkTracerProvider,
-    tracing::info,
-    tracing_subscriber::layer::SubscriberExt,
-    tracing_subscriber::util::SubscriberInitExt,
-    tracing_subscriber::{EnvFilter, fmt},
-};
+use tracing::info;
+use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
 #[cfg(test)]
 use std::println as info;
@@ -262,7 +258,7 @@ async fn run_merge(paths: Vec<PathBuf>, args: Args) -> Result<()> {
 /// bigtent -r /path/to/clusters --lookup identifiers.json
 /// bigtent -r /path/to/clusters --lookup identifiers.json --output results.json
 /// ```
-async fn run_lookup(path_vec: &Vec<PathBuf>, args: &Args) -> Result<()> {
+async fn run_lookup(path_vec: &[PathBuf], args: &Args) -> Result<()> {
     // Extract and validate the lookup file path
     let lookup_path = match &args.lookup {
         Some(p) => p.clone(),
@@ -391,7 +387,7 @@ async fn run_check(cluster_source: &ClusterSource, args: &Args) -> bool {
             continue;
         }
 
-        match load_clusters_from_dirs(&[dir.clone()], args.pre_cache_index()).await {
+        match load_clusters_from_dirs(std::slice::from_ref(dir), args.pre_cache_index()).await {
             Ok(members) => {
                 if members.is_empty() {
                     eprintln!("WARNING: No cluster files found in {:?}", dir);

--- a/src/rodeo/goat.rs
+++ b/src/rodeo/goat.rs
@@ -89,11 +89,11 @@ struct IndexOffset {
 }
 
 impl IndexOffset {
-    pub fn from_index_files(index_files: &Vec<Arc<IndexFile>>) -> Arc<Vec<IndexOffset>> {
+    pub fn from_index_files(index_files: &[Arc<IndexFile>]) -> Arc<Vec<IndexOffset>> {
         let mut ret = vec![];
         let mut total_offset = 0usize;
 
-        let mut sorted_index_files = index_files.clone();
+        let mut sorted_index_files = index_files.to_owned();
         sorted_index_files.sort_by(|a, b| {
             a.read_index_at_byte_offset(0)
                 .expect("Should be able to load index")
@@ -115,7 +115,7 @@ impl IndexOffset {
         Arc::new(ret)
     }
 
-    pub fn find(offsets: &Vec<IndexOffset>, pos: usize) -> Option<IndexOffset> {
+    pub fn find(offsets: &[IndexOffset], pos: usize) -> Option<IndexOffset> {
         match offsets.binary_search_by(|cmp| {
             if pos < cmp.start {
                 Ordering::Greater
@@ -232,10 +232,7 @@ impl GoatRodeoTrait for GoatRodeoCluster {
     }
 
     fn has_identifier(&self, identifier: &str) -> bool {
-        match self.identifier_to_item_offset(identifier) {
-            Some(_) => true,
-            _ => false,
-        }
+        self.identifier_to_item_offset(identifier).is_some()
     }
 
     fn is_empty(&self) -> bool {
@@ -243,11 +240,7 @@ impl GoatRodeoTrait for GoatRodeoCluster {
     }
 
     fn read_history(&self) -> Result<Vec<serde_json::Value>> {
-        let history_path = self
-            .cluster_path
-            .canonicalize()
-            .with_context(|| format!("Could not canonicalize {:?}", self.cluster_path))?
-            .with_file_name("history.jsonl");
+        let history_path = self.cluster_path.with_file_name("history.jsonl");
 
         if !history_path.exists() || !history_path.is_file() {
             return Ok(vec![]);
@@ -274,7 +267,8 @@ impl GoatRodeoTrait for GoatRodeoCluster {
     async fn roots(self: Arc<Self>) -> Receiver<Item> {
         let (tx, rx) = tokio::sync::mpsc::channel(256);
 
-        let _ = tokio::spawn(async move {
+        // FIXME: this should be restructured for structured concurrency
+        tokio::spawn(async move {
             for offset in 0..self.number_of_items {
                 if let Some(item_offset) = self.offset_from_pos(offset) {
                     if let Some(item) = self.item_from_item_offset(&item_offset) {
@@ -308,12 +302,10 @@ impl ClusterRoboMember for GoatRodeoCluster {
                             pos,
                             index.len()
                         );
-                        return None;
+                        None
                     }
                 }
-                None => {
-                    return None;
-                }
+                None => None,
             }
         } else {
             let byte_pos = pos * 32;
@@ -323,10 +315,10 @@ impl ClusterRoboMember for GoatRodeoCluster {
                         Some(index) => {
                             let relative_byte_pos = byte_pos - index_hash.start; // get the item
                             match index.read_index_at_byte_offset(relative_byte_pos) {
-                                Ok(v) => return Some(v),
+                                Ok(v) => Some(v),
                                 Err(e) => {
                                     error!("Unable to read at {} error {:?}", relative_byte_pos, e);
-                                    return None;
+                                    None
                                 }
                             }
                         }
@@ -335,7 +327,7 @@ impl ClusterRoboMember for GoatRodeoCluster {
                                 "for {:?} in offset_from_pos: Pos {} lead to index file {:x} which can't be found",
                                 self.cluster_path, pos, index_hash.index_file
                             );
-                            return None;
+                            None
                         }
                     }
                 }
@@ -344,7 +336,7 @@ impl ClusterRoboMember for GoatRodeoCluster {
                         "for {:?} in offset_from_pos 2: Pos {} outside index len {}",
                         self.cluster_path, pos, self.number_of_items
                     );
-                    return None;
+                    None
                 }
             }
         }
@@ -361,12 +353,12 @@ impl GoatRodeoCluster {
     }
 
     /// Get the data file mapping
-    pub fn get_data_files<'a>(&'a self) -> &'a HashMap<u64, Arc<DataFile>> {
+    pub fn get_data_files(&self) -> &HashMap<u64, Arc<DataFile>> {
         &self.data_files
     }
 
     /// Get the index file mapping
-    pub fn get_index_files<'a>(&'a self) -> &'a HashMap<u64, Arc<IndexFile>> {
+    pub fn get_index_files(&self) -> &HashMap<u64, Arc<IndexFile>> {
         &self.index_files
     }
 
@@ -390,7 +382,7 @@ impl GoatRodeoCluster {
         let load_index = pre_cache_index;
         let start = Instant::now();
         let file_path = cluster_path.clone();
-        let file_name = match file_path.file_name().map(|e| e.to_str()).flatten() {
+        let file_name = match file_path.file_name().and_then(|e| e.to_str()) {
             Some(n) => n.to_string(),
             _ => bail!("Unable to get filename for {:?}", file_path),
         };
@@ -485,7 +477,7 @@ impl GoatRodeoCluster {
             indexed_hashes.remove(data_key);
         }
 
-        if indexed_hashes.len() != 0 {
+        if !indexed_hashes.is_empty() {
             bail!("Indexes looking for files {}, but they were not found", {
                 let mut files = vec![];
                 for v in indexed_hashes {
@@ -508,13 +500,11 @@ impl GoatRodeoCluster {
             number_of_items,
             blob,
             sha,
-            name: format!(
-                "{}",
-                cluster_path
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .unwrap_or("unknown_cluster_name")
-            ),
+            name: cluster_path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("unknown_cluster_name")
+                .to_string(),
             load_index,
             directory: parent,
             index_offset: IndexOffset::from_index_files(&index_vec),
@@ -534,10 +524,7 @@ impl GoatRodeoCluster {
     }
 
     pub fn common_parent_dir(clusters: &[GoatRodeoCluster]) -> Result<PathBuf> {
-        let paths = clusters
-            .into_iter()
-            .map(|b| b.cluster_path.clone())
-            .collect();
+        let paths = clusters.iter().map(|b| b.cluster_path.clone()).collect();
         find_common_root_dir(paths)
     }
 
@@ -555,11 +542,8 @@ impl GoatRodeoCluster {
         let tmp = self.index.load().clone();
 
         // if it's already built, just return it
-        match tmp.deref() {
-            Some(v) => {
-                return Ok(v.clone());
-            }
-            None => {}
+        if let Some(v) = tmp.deref() {
+            return Ok(v.clone());
         }
 
         if !self.load_index {
@@ -573,11 +557,8 @@ impl GoatRodeoCluster {
 
         // test again after acquiring the lock
         let tmp = self.index.load().clone();
-        match tmp.deref() {
-            Some(v) => {
-                return Ok(v.clone());
-            }
-            None => {}
+        if let Some(v) = tmp.deref() {
+            return Ok(v.clone());
         }
 
         let mut ret = vec![];
@@ -591,7 +572,7 @@ impl GoatRodeoCluster {
             };
 
             let the_index = index.read_index()?;
-            if the_index.len() > 0 {
+            if !the_index.is_empty() {
                 vecs.push(the_index);
             }
         }
@@ -613,9 +594,9 @@ impl GoatRodeoCluster {
                 start.elapsed()
             );
 
-            if ret.len() == 0 {
+            if !ret.is_empty() {
                 ret = the_index;
-            } else if the_index.len() == 0 {
+            } else if the_index.is_empty() {
 
                 // do nothing... nothing to sort
             } else if the_index[0].hash > ret[ret.len() - 1].hash {
@@ -673,7 +654,7 @@ impl GoatRodeoCluster {
             start.elapsed()
         );
 
-        let ret_arc: Arc<Vec<ItemOffset>> = Arc::new(ret.into());
+        let ret_arc: Arc<Vec<ItemOffset>> = Arc::new(ret);
         self.index.store(Arc::new(Some(ret_arc.clone())));
         // keep the lock alive
         *my_lock = false;
@@ -704,7 +685,7 @@ impl GoatRodeoCluster {
         suffix: &str,
     ) -> Result<File> {
         fn find(name: &str, dir: &Path) -> Result<Option<PathBuf>> {
-            for entry in dir.read_dir()?.into_iter() {
+            for entry in dir.read_dir()? {
                 let entry = entry?;
 
                 if match entry.file_name().into_string() {
@@ -716,9 +697,8 @@ impl GoatRodeoCluster {
                 }
                 let path = entry.path();
                 if path.is_dir() {
-                    match find(name, &path)? {
-                        Some(s) => return Ok(Some(s)),
-                        _ => {}
+                    if let Some(s) = find(name, &path)? {
+                        return Ok(Some(s));
                     }
                 }
             }
@@ -752,8 +732,7 @@ impl GoatRodeoCluster {
             let file_extn = file
                 .path()
                 .extension()
-                .map(|e| e.to_str())
-                .flatten()
+                .and_then(|e| e.to_str())
                 .map(|s| s.to_owned());
 
             let file_type = file.file_type().await?;
@@ -798,7 +777,7 @@ impl GoatRodeoCluster {
         if self.load_index && self.index.load().is_some() {
             match &**self.index.load() {
                 Some(index) => find_item_offset(hash, index),
-                None => return None,
+                None => None,
             }
         } else {
             if self.number_of_items() == 0 {
@@ -812,7 +791,7 @@ impl GoatRodeoCluster {
                 let entry = self.offset_from_pos(mid)?;
                 match entry.hash.cmp(&hash) {
           Ordering::Less => low = mid + 1,
-          Ordering::Equal => return Some(entry.clone()),
+          Ordering::Equal => return Some(entry),
           Ordering::Greater if mid != 0 => hi = mid - 1,
           Ordering::Greater /* mid == 0 */ => return None,
         }
@@ -842,7 +821,7 @@ impl GoatRodeoCluster {
     }
 
     pub fn item_from_index_loc(&self, index_loc: &ItemLoc) -> Option<Item> {
-        Some(self.item_for_file_and_offset(index_loc.get_file_hash(), index_loc.get_offset())?)
+        self.item_for_file_and_offset(index_loc.get_file_hash(), index_loc.get_offset())
     }
 }
 
@@ -975,19 +954,13 @@ async fn test_files_in_dir() {
         return;
     }
 
-    let files = match GoatRodeoCluster::cluster_files_in_dir(
+    let files = GoatRodeoCluster::cluster_files_in_dir(
         "../goatrodeo/res_for_big_tent/".into(),
         true,
         vec![],
     )
     .await
-    {
-        Ok(v) => v,
-        Err(e) => {
-            assert!(false, "Failure to read files {:?}", e);
-            return;
-        }
-    };
+    .expect("Failure to read files");
 
     assert!(!files.is_empty(), "We should find some files");
     let mut total_index_size = 0;
@@ -1095,14 +1068,9 @@ async fn test_generated_cluster_no_index() {
         }
 
         let start = Instant::now();
-        let files =
-            match GoatRodeoCluster::cluster_files_in_dir(test_path.into(), false, vec![]).await {
-                Ok(v) => v,
-                Err(e) => {
-                    assert!(false, "Failure to read files {:?}", e);
-                    return;
-                }
-            };
+        let files = GoatRodeoCluster::cluster_files_in_dir(test_path.into(), false, vec![])
+            .await
+            .expect("Failure to read files");
 
         info!(
             "Finding files took {:?}",
@@ -1148,25 +1116,19 @@ async fn test_files_in_dir_no_index_load() {
         return;
     }
 
-    let files = match GoatRodeoCluster::cluster_files_in_dir(
+    let files = GoatRodeoCluster::cluster_files_in_dir(
         "../goatrodeo/res_for_big_tent/".into(),
         false,
         vec![],
     )
     .await
-    {
-        Ok(v) => v,
-        Err(e) => {
-            assert!(false, "Failure to read files {:?}", e);
-            return;
-        }
-    };
+    .expect("Failure to read files");
 
-    assert!(files.len() > 0, "We should find some files");
+    assert!(!files.is_empty(), "We should find some files");
     let mut total_index_size = 0;
     for cluster in &files {
-        assert!(cluster.data_files.len() > 0);
-        assert!(cluster.index_files.len() > 0);
+        assert!(!cluster.data_files.is_empty());
+        assert!(!cluster.index_files.is_empty());
 
         let start = Instant::now();
         let complete_index_len = cluster.number_of_items();

--- a/src/rodeo/goat.rs
+++ b/src/rodeo/goat.rs
@@ -856,22 +856,17 @@ async fn test_antialias() {
         return;
     }
 
-    let mut files = match GoatRodeoCluster::cluster_files_in_dir(
+    let mut files = GoatRodeoCluster::cluster_files_in_dir(
         "../goatrodeo/res_for_big_tent/".into(),
         true,
         vec![],
     )
     .await
-    {
-        Ok(v) => v,
-        Err(e) => {
-            assert!(false, "Failure to read files {:?}", e);
-            return;
-        }
-    };
+    .expect("To read file");
+
     println!("Read cluster at {:?}", start.elapsed());
 
-    assert!(files.len() > 0, "Need a cluster");
+    assert!(!files.is_empty(), "Need a cluster");
     let cluster = files.pop().expect("Expect a cluster");
     let index = cluster
         .get_md5_to_item_offset_index_if_load_index_true()
@@ -931,20 +926,15 @@ async fn test_generated_cluster() {
         }
 
         let start = Instant::now();
-        let files =
-            match GoatRodeoCluster::cluster_files_in_dir(test_path.into(), true, vec![]).await {
-                Ok(v) => v,
-                Err(e) => {
-                    assert!(false, "Failure to read files {:?}", e);
-                    return;
-                }
-            };
+        let files = GoatRodeoCluster::cluster_files_in_dir(test_path.into(), true, vec![])
+            .await
+            .expect("Failure to read files");
 
         info!(
             "Finding files took {:?}",
             Instant::now().duration_since(start)
         );
-        assert!(files.len() > 0, "We should find some files");
+        assert!(!files.is_empty(), "We should find some files");
         let mut pass_num = 0;
         for cluster in files {
             pass_num += 1;
@@ -999,11 +989,11 @@ async fn test_files_in_dir() {
         }
     };
 
-    assert!(files.len() > 0, "We should find some files");
+    assert!(!files.is_empty(), "We should find some files");
     let mut total_index_size = 0;
     for cluster in &files {
-        assert!(cluster.data_files.len() > 0);
-        assert!(cluster.index_files.len() > 0);
+        assert!(!cluster.data_files.is_empty());
+        assert!(!cluster.index_files.is_empty());
 
         let start = Instant::now();
         let complete_index = cluster
@@ -1118,7 +1108,7 @@ async fn test_generated_cluster_no_index() {
             "Finding files took {:?}",
             Instant::now().duration_since(start)
         );
-        assert!(files.len() > 0, "We should find some files");
+        assert!(!files.is_empty(), "We should find some files");
         let mut pass_num = 0;
         for cluster in files {
             pass_num += 1;

--- a/src/rodeo/goat.rs
+++ b/src/rodeo/goat.rs
@@ -195,10 +195,7 @@ impl GoatRodeoTrait for GoatRodeoCluster {
     }
 
     fn get_purl(&self) -> Result<PathBuf> {
-        Ok(self
-            .cluster_path
-            .canonicalize()?
-            .with_file_name("purls.txt"))
+        Ok(self.cluster_path.with_file_name("purls.txt"))
     }
 
     /// get the number of items this cluster is managing

--- a/src/rodeo/goat_herd.rs
+++ b/src/rodeo/goat_herd.rs
@@ -175,7 +175,8 @@ impl GoatRodeoTrait for GoatHerd {
     async fn roots(self: Arc<GoatHerd>) -> Receiver<Item> {
         let (tx, rx) = tokio::sync::mpsc::channel(256);
 
-        let _ = tokio::spawn(async move {
+        // FIXME: this should be structured concurrency, not detached
+        tokio::spawn(async move {
             for goat in &self.herd {
                 let mut real_rx: Receiver<Item> = call_root(goat).await;
                 while let Some(v) = real_rx.recv().await {

--- a/src/rodeo/goat_trait.rs
+++ b/src/rodeo/goat_trait.rs
@@ -132,35 +132,32 @@ pub async fn impl_stream_flattened_items<GRT: GoatRodeoTrait + 'static>(
         while !to_find.is_empty() {
             let mut new_to_find = HashSet::new();
             for identifier in to_find.clone() {
-                match the_self.item_for_identifier(&identifier) {
-                    Some(item) => {
-                        // deal with anti-aliasing
-                        item.connections
-                            .iter()
-                            .filter(|a| a.0.is_alias_to())
-                            .for_each(|s| {
-                                if !to_find.contains(&s.1) && !processed.contains(&s.1) {
-                                    new_to_find.insert(s.1.clone());
-                                }
-                            });
-
-                        // process
-                        for s in item
-                            .connections
-                            .iter()
-                            .filter(|a| a.0.is_contains_down() || (source && a.0.is_built_from()))
-                        {
+                if let Some(item) = the_self.item_for_identifier(&identifier) {
+                    // deal with anti-aliasing
+                    item.connections
+                        .iter()
+                        .filter(|a| a.0.is_alias_to())
+                        .for_each(|s| {
                             if !to_find.contains(&s.1) && !processed.contains(&s.1) {
                                 new_to_find.insert(s.1.clone());
+                            }
+                        });
 
-                                // if we are looking at source only, only include build sources
-                                if !source || s.0.is_built_from() {
-                                    let _ = tx.send(Either::Right(s.1.clone())).await;
-                                }
+                    // process
+                    for s in item
+                        .connections
+                        .iter()
+                        .filter(|a| a.0.is_contains_down() || (source && a.0.is_built_from()))
+                    {
+                        if !to_find.contains(&s.1) && !processed.contains(&s.1) {
+                            new_to_find.insert(s.1.clone());
+
+                            // if we are looking at source only, only include build sources
+                            if !source || s.0.is_built_from() {
+                                let _ = tx.send(Either::Right(s.1.clone())).await;
                             }
                         }
                     }
-                    _ => {}
                 }
                 processed.insert(identifier);
             }
@@ -289,35 +286,32 @@ pub async fn impl_north_send<GRT: GoatRodeoTrait + 'static>(
             // Get items we haven't visited yet
             let to_search = less(&to_find, &found);
 
-            if to_search.len() == 0 {
+            if to_search.is_empty() {
                 break; // All reachable items visited
             }
 
             for this_oid in to_search {
                 found.insert(this_oid.clone()); // Mark as visited
 
-                match the_self.item_for_identifier(&this_oid) {
-                    Some(item) => {
-                        // Find containers/builders of this item (upward edges)
-                        let and_then = item.contained_by();
+                if let Some(item) = the_self.item_for_identifier(&this_oid) {
+                    // Find containers/builders of this item (upward edges)
+                    let and_then = item.contained_by();
 
-                        if purls_only {
-                            // Only stream unique PURLs
-                            for purl in item.find_purls() {
-                                if !found_purls.contains(&purl) {
-                                    let _ = tx.send(Either::Right(purl.clone())).await;
-                                    found_purls.insert(purl);
-                                }
+                    if purls_only {
+                        // Only stream unique PURLs
+                        for purl in item.find_purls() {
+                            if !found_purls.contains(&purl) {
+                                let _ = tx.send(Either::Right(purl.clone())).await;
+                                found_purls.insert(purl);
                             }
-                        } else {
-                            // Stream the full item
-                            let _ = tx.send(Either::Left(item)).await;
                         }
-
-                        // Add containers to next iteration's work
-                        to_find = to_find.union(&and_then).map(|s| s.clone()).collect();
+                    } else {
+                        // Stream the full item
+                        let _ = tx.send(Either::Left(item)).await;
                     }
-                    _ => {} // Item not found, skip
+
+                    // Add containers to next iteration's work
+                    to_find = to_find.union(&and_then).cloned().collect();
                 }
                 cnt.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             }

--- a/src/rodeo/holder.rs
+++ b/src/rodeo/holder.rs
@@ -79,7 +79,8 @@ impl MetricsHandles {
         let registry = Registry::new_custom(None, None)?;
 
         // Register process metrics (Linux only)
-        #[cfg(target_os = "linux")] {
+        #[cfg(target_os = "linux")]
+        {
             let process_collector = prometheus::process_collector::ProcessCollector::for_self();
             registry.register(Box::new(process_collector))?;
         }

--- a/src/rodeo/index.rs
+++ b/src/rodeo/index.rs
@@ -97,7 +97,7 @@ impl IndexFile {
         // ensure we close `file` after computing the hash
         if check_hash {
             let mut file = GoatRodeoCluster::find_data_or_index_file_from_sha256(
-                &dir,
+                dir,
                 hash,
                 GOAT_RODEO_INDEX_FILE_SUFFIX,
             )
@@ -114,7 +114,7 @@ impl IndexFile {
         }
 
         let file = GoatRodeoCluster::find_data_or_index_file_from_sha256(
-            &dir,
+            dir,
             hash,
             GOAT_RODEO_INDEX_FILE_SUFFIX,
         )
@@ -178,7 +178,7 @@ impl IndexFile {
 
     pub fn read_index_at_byte_offset(&self, pos: usize) -> Result<ItemOffset> {
         let mut info: &[u8] = &self.file[(self.data_offset + pos)..];
-        Ok(ItemOffset::read(&mut info)?)
+        ItemOffset::read(&mut info)
     }
 }
 
@@ -209,17 +209,17 @@ pub struct ItemOffset {
 }
 
 pub trait HasHash {
-    fn hash<'a>(&'a self) -> &'a MD5Hash;
+    fn hash(&self) -> &MD5Hash;
 }
 
 impl HasHash for ItemOffset {
-    fn hash<'a>(&'a self) -> &'a MD5Hash {
+    fn hash(&self) -> &MD5Hash {
         &self.hash
     }
 }
 
 pub(crate) fn find_item_offset(to_find: [u8; 16], offsets: &[ItemOffset]) -> Option<ItemOffset> {
-    if offsets.len() == 0 {
+    if !offsets.is_empty() {
         return None;
     }
 

--- a/src/rodeo/robo_goat.rs
+++ b/src/rodeo/robo_goat.rs
@@ -128,7 +128,7 @@ impl RoboticGoat {
 
             let body: serde_cbor::Value = serde_cbor::from_reader(&ser[..])?;
 
-            let identifier = format!("tag:sha256:{}", hex::encode(&sha256_for_slice(&ser)));
+            let identifier = format!("tag:sha256:{}", hex::encode(sha256_for_slice(&ser)));
 
             let i = Item {
                 identifier: identifier.clone(),
@@ -215,13 +215,13 @@ async fn test_synthetic() {
     assert_eq!(tagged.len(), 1, "Expecting 1 tag, got {:?}", tagged);
 
     for t in &tagged {
-        let the_tag = herd.item_for_identifier(&t).expect("Get tag");
+        let the_tag = herd.item_for_identifier(t).expect("Get tag");
         let the_tag_id = &the_tag.identifier;
         for (t, v) in &the_tag.connections {
             if t.is_tag_to() {
                 let tagged_item = herd
                     .item_for_identifier(v)
-                    .expect(&format!("Should load {}", v));
+                    .unwrap_or_else(|| panic!("Should load {}", v));
                 assert_eq!(
                     1,
                     tagged_item
@@ -291,8 +291,7 @@ impl GoatRodeoTrait for RoboticGoat {
             Ok(v) => v,
             Err(_) => return None,
         };
-        let res = self.item_from_item_offset(&self.offsets[found]);
-        res
+        self.item_from_item_offset(&self.offsets[found])
     }
 
     fn antialias_for(self: Arc<Self>, data: &str) -> Option<Item> {

--- a/src/server.rs
+++ b/src/server.rs
@@ -126,13 +126,10 @@ async fn stream_items<GRT: GoatRodeoTrait + 'static>(
 
     tokio::spawn(async move {
         for item_id in items {
-            match rodeo.get_cluster().item_for_identifier(&item_id) {
-                Some(i) => {
-                    if !mtx.is_closed() {
-                        let _ = mtx.send(i).await;
-                    }
+            if let Some(i) = rodeo.get_cluster().item_for_identifier(&item_id) {
+                if !mtx.is_closed() {
+                    let _ = mtx.send(i).await;
                 }
-                _ => {}
             }
         }
     });
@@ -334,7 +331,7 @@ async fn do_serve_gitoid<GRT: GoatRodeoTrait + 'static>(
     maybe_gitoid: Option<&String>,
 ) -> Result<Json<Item>, (StatusCode, Json<String>)> {
     if let Some(gitoid) = maybe_gitoid {
-        let ret = rodeo.get_cluster().item_for_identifier(&gitoid);
+        let ret = rodeo.get_cluster().item_for_identifier(gitoid);
 
         match ret {
             Some(item) => Ok(Json(item)),
@@ -346,7 +343,7 @@ async fn do_serve_gitoid<GRT: GoatRodeoTrait + 'static>(
     } else {
         Err((
             StatusCode::NOT_FOUND,
-            Json(format!("No 'identifier' supplied")),
+            Json("No 'identifier' supplied".to_string()),
         ))
     }
 }
@@ -410,11 +407,8 @@ async fn anti_alias_bulk<GRT: GoatRodeoTrait + 'static>(
     let mut ret = HashMap::new();
     let cluster = rodeo.get_cluster();
     for key in payload {
-        match cluster.clone().antialias_for(&key) {
-            Some(item) => {
-                ret.insert(key, item);
-            }
-            None => {}
+        if let Some(item) = cluster.clone().antialias_for(&key) {
+            ret.insert(key, item);
         }
     }
 
@@ -425,7 +419,7 @@ async fn do_serve_anti_alias<GRT: GoatRodeoTrait + 'static>(
     gitoid: Option<&String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<String>)> {
     if let Some(to_find) = gitoid {
-        let ret = rodeo.get_cluster().antialias_for(&to_find);
+        let ret = rodeo.get_cluster().antialias_for(to_find);
 
         match ret {
             Some(item) => Ok(Json(item.to_json())),
@@ -437,7 +431,7 @@ async fn do_serve_anti_alias<GRT: GoatRodeoTrait + 'static>(
     } else {
         Err((
             StatusCode::NOT_FOUND,
-            Json(format!("No 'identifier' supplied")),
+            Json("No 'identifier' supplied".to_string()),
         ))
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -34,7 +34,7 @@ use std::{
     collections::{BTreeMap, HashSet},
     ffi::OsStr,
     io::{Read, Write},
-    path::PathBuf,
+    path::{Path, PathBuf},
     time::{Duration, SystemTime},
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -113,9 +113,8 @@ pub fn byte_slice_to_u63(it: &[u8]) -> Result<u64> {
         );
     }
 
-    for x in 0..8 {
-        buff[x] = it[x];
-    }
+    buff.copy_from_slice(&it[..8]);
+
     // Mask off high bit to get 63-bit value
     Ok(u64::from_be_bytes(buff) & 0x7fffffffffffffff)
 }
@@ -233,7 +232,7 @@ pub fn current_date_string() -> String {
     format!("{:?}", chrono::offset::Utc::now())
 }
 
-pub fn is_child_dir(root: &PathBuf, potential_child: &PathBuf) -> Result<bool> {
+pub fn is_child_dir(root: &Path, potential_child: &PathBuf) -> Result<bool> {
     let full_root = root.canonicalize()?;
 
     let full_kid = potential_child
@@ -296,7 +295,7 @@ pub fn find_common_root_dir(from: Vec<PathBuf>) -> Result<PathBuf> {
 
     let mut root = with_parents[0].1.clone();
     for j in &with_parents {
-        root = root.intersection(&j.1).map(|v| v.clone()).collect();
+        root = root.intersection(&j.1).cloned().collect();
     }
 
     if root.len() <= 1 {
@@ -343,8 +342,8 @@ pub fn os_str_to_string(oss: &OsStr) -> Result<String> {
     }
 }
 
-pub fn path_plus_timed(root: &PathBuf, suffix: &str) -> PathBuf {
-    let mut ret = root.clone();
+pub fn path_plus_timed(root: &Path, suffix: &str) -> PathBuf {
+    let mut ret = root.to_path_buf();
     ret.push(timed_filename(suffix));
     ret
 }
@@ -372,7 +371,7 @@ pub async fn read_all<R: AsyncReadExt + Unpin>(r: &mut R, max: usize) -> Result<
     let mut read: usize = 0;
     loop {
         let to_read = BYTE_BUFFER_SIZE.min(max - read);
-        if to_read <= 0 {
+        if to_read == 0 {
             break;
         }
         match r.read(&mut buf[0..to_read]).await {
@@ -430,10 +429,7 @@ pub async fn read_len_and_cbor<T: DeserializeOwned, R: AsyncReadExt + Unpin>(
     file: &mut R,
 ) -> Result<T> {
     let len = read_u16(file).await? as usize;
-    let mut buffer = Vec::with_capacity(len);
-    for _ in 0..len {
-        buffer.push(0u8);
-    }
+    let mut buffer = vec![0u8; len];
     file.read_exact(&mut buffer).await?;
 
     serde_cbor::from_reader(&*buffer).map_err(|e| e.into())
@@ -441,10 +437,7 @@ pub async fn read_len_and_cbor<T: DeserializeOwned, R: AsyncReadExt + Unpin>(
 
 pub fn read_len_and_cbor_sync<T: DeserializeOwned, R: Read>(file: &mut R) -> Result<T> {
     let len = read_u16_sync(file)? as usize;
-    let mut buffer = Vec::with_capacity(len);
-    for _ in 0..len {
-        buffer.push(0u8);
-    }
+    let mut buffer = vec![0u8; len];
     file.read_exact(&mut buffer)?;
 
     serde_cbor::from_reader(&*buffer).map_err(|e| e.into())
@@ -454,16 +447,13 @@ pub async fn read_cbor<T: DeserializeOwned, R: AsyncReadExt + Unpin>(
     file: &mut R,
     len: usize,
 ) -> Result<T> {
-    let mut buffer = Vec::with_capacity(len);
-    for _ in 0..len {
-        buffer.push(0u8);
-    }
+    let mut buffer = vec![0u8; len];
     file.read_exact(&mut buffer).await?;
 
-    match serde_cbor::from_slice(&*buffer) {
+    match serde_cbor::from_slice(&buffer) {
         Ok(v) => Ok(v),
         Err(e) => {
-            match serde_cbor::from_slice::<Value>(&*&buffer) {
+            match serde_cbor::from_slice::<Value>(&buffer) {
                 Ok(v) => {
                     info!("Deserialized value {:?} but got error {}", v, e);
                 }
@@ -482,16 +472,13 @@ pub async fn read_cbor<T: DeserializeOwned, R: AsyncReadExt + Unpin>(
 }
 
 pub fn read_cbor_sync<T: DeserializeOwned, R: Read + Unpin>(file: &mut R, len: usize) -> Result<T> {
-    let mut buffer = Vec::with_capacity(len);
-    for _ in 0..len {
-        buffer.push(0u8);
-    }
+    let mut buffer = vec![0u8; len];
     file.read_exact(&mut buffer)?;
 
-    match serde_cbor::from_slice(&*buffer) {
+    match serde_cbor::from_slice(&buffer) {
         Ok(v) => Ok(v),
         Err(e) => {
-            match serde_cbor::from_slice::<Value>(&*&buffer) {
+            match serde_cbor::from_slice::<Value>(&buffer) {
                 Ok(v) => {
                     info!("Deserialized value {:?} but got error {}", v, e);
                 }
@@ -572,21 +559,21 @@ pub fn traverse_value(v: &Value, path: Vec<&str>) -> Option<Value> {
     Some(first.clone())
 }
 
-pub fn as_obj<'a>(v: &'a Value) -> Option<&'a BTreeMap<Value, Value>> {
+pub fn as_obj(v: &Value) -> Option<&BTreeMap<Value, Value>> {
     match v {
         Value::Map(m) => Some(m),
         _ => None,
     }
 }
 
-pub fn as_array<'a>(v: &'a Value) -> Option<&'a Vec<Value>> {
+pub fn as_array(v: &Value) -> Option<&Vec<Value>> {
     match v {
         Value::Array(m) => Some(m),
         _ => None,
     }
 }
 
-pub fn as_str<'a>(v: &'a Value) -> Option<&'a String> {
+pub fn as_str(v: &Value) -> Option<&String> {
     match v {
         Value::Text(s) => Some(s),
         _ => None,


### PR DESCRIPTION
First, `clippy` is happy now.

Second, we make the filenames for the history file consistently with the other uses of cluster_file, and by not forcing canonicalization, we don't trigger the intermediate steps that abort the merge.