### PR TITLE
fresh_merge: exit threads cleanly when channel receiver is gone (no more panics on shutdown-during-merge)

### DIFF
--- a/src/fresh_merge.rs
+++ b/src/fresh_merge.rs
@@ -207,10 +207,12 @@ pub async fn merge_fresh<PB: Into<PathBuf>>(
                 // Returns None when all clusters are exhausted
                 match next_hash_of_item_to_merge(&mut index_holder) {
                     Some(items_to_merge) => {
-                        // Send work to worker threads
-                        offset_tx
-                            .send((pos, items_to_merge))
-                            .expect("Should be able to send the message");
+                        // If the receiver is gone (workers have all exited, or the
+                        // caller's async task was cancelled), stop cleanly instead
+                        // of panicking.
+                        if offset_tx.send((pos, items_to_merge)).is_err() {
+                            break;
+                        }
                         pos += 1;
                     }
                     // All clusters exhausted - we're done!
@@ -267,14 +269,21 @@ pub async fn merge_fresh<PB: Into<PathBuf>>(
                 let cbor_bytes =
                     serde_cbor::to_vec(&top).expect("Should be able to encode an item");
 
-                tx.send(ItemOrPurl::Item {
-                    pos: position,
-                    item: top,
-                    cbor_bytes,
-                    merged: items_to_merge.len() - 1,
-                    purls,
-                })
-                .expect("Should send message");
+                // If the main thread's receiver is gone (e.g. the caller's async
+                // task was cancelled during shutdown), stop cleanly instead of
+                // panicking.
+                if tx
+                    .send(ItemOrPurl::Item {
+                        pos: position,
+                        item: top,
+                        cbor_bytes,
+                        merged: items_to_merge.len() - 1,
+                        purls,
+                    })
+                    .is_err()
+                {
+                    return;
+                }
                 #[cfg(feature = "extra_progress")]
                 {
                     cnt += 1;


### PR DESCRIPTION
fresh_merge: stop threads cleanly when receiver is gone

The coordinator and worker threads in merge_fresh used .expect() on
channel sends, which panicked when the receiver was dropped. This
fires 21 times (1 coordinator + 20 workers) on every pod termination
that happens during a merge, because OS threads outlive the tokio
task whose cancellation drops the receiving side of the final
channel.

A closed channel on the producer side is a legitimate terminal
signal, not a bug. Treat it as "nothing more to do" and exit the
thread cleanly.