### PR TITLE
More canonicalization fixes: log errors but continue on malformed clusters

### DIFF
--- a/src/rodeo/goat.rs
+++ b/src/rodeo/goat.rs
@@ -237,21 +237,27 @@ impl GoatRodeoTrait for GoatRodeoCluster {
     }
 
     fn read_history(&self) -> Result<Vec<serde_json::Value>> {
-        let history_path = self
-            .cluster_path
-            .canonicalize()
-            .with_context(|| format!("Could not canonicalize {:?}", self.cluster_path))?
-            .with_file_name("history.jsonl");
+        let history_path = self.cluster_path.with_file_name("history.jsonl");
 
         if !history_path.exists() || !history_path.is_file() {
             return Ok(vec![]);
         }
 
-        let lines = json_lines::<serde_json::Value, _>(&history_path)
-            .with_context(|| format!("Could not read JSON {:?}", history_path))?;
+        let lines = match json_lines::<serde_json::Value, _>(&history_path) {
+            Ok(l) => l,
+            Err(e) => {
+                error!("Could not open history file {:?}: {}", history_path, e);
+                return Ok(vec![]);
+            }
+        };
         let mut ret = vec![];
         for line in lines {
-            ret.push(line?);
+            match line {
+                Ok(v) => ret.push(v),
+                Err(e) => {
+                    error!("Skipping malformed line in {:?}: {}", history_path, e);
+                }
+            }
         }
 
         Ok(ret)


### PR DESCRIPTION
- remove unnecessary canonicalize, use direct with_file_name like get_purl does
- gracefully handle missing cluster files (return empty vec + warn instead of error)
