### PR TITLE
Read goatrodeo's concise input format

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -312,6 +312,174 @@ pub const BUILT_FROM: &str = "build:down";
 pub const TAG_FROM: &str = "tag:from";
 pub const TAG_TO: &str = "tag:to";
 
+// ─────────────────────────────────────────────────────────────────────────
+//  EdgeTypeId — compact byte identifiers for the eight known edge types.
+//  Mirrors goatrodeo's `io.spicelabs.goatrodeo.util.EdgeTypeId`. The table
+//  is append-only — values are part of the v3 wire format.
+// ─────────────────────────────────────────────────────────────────────────
+
+pub mod edge_type_id {
+    use super::*;
+
+    pub const CONTAINED_BY_ID: u8 = 0;
+    pub const CONTAINS_ID:     u8 = 1;
+    pub const ALIAS_FROM_ID:   u8 = 2;
+    pub const ALIAS_TO_ID:     u8 = 3;
+    pub const BUILDS_TO_ID:    u8 = 4;
+    pub const BUILT_FROM_ID:   u8 = 5;
+    pub const TAG_FROM_ID:     u8 = 6;
+    pub const TAG_TO_ID:       u8 = 7;
+
+    /// Map a byte ID back to its canonical edge-type string. Returns
+    /// `None` when the ID is not in the well-known table; callers should
+    /// fall back to the [`WireEdge::UnknownType`] variant.
+    pub fn to_str(id: u8) -> Option<&'static str> {
+        match id {
+            CONTAINED_BY_ID => Some(CONTAINED_BY),
+            CONTAINS_ID     => Some(CONTAINS),
+            ALIAS_FROM_ID   => Some(ALIAS_FROM),
+            ALIAS_TO_ID     => Some(ALIAS_TO),
+            BUILDS_TO_ID    => Some(BUILDS_TO),
+            BUILT_FROM_ID   => Some(BUILT_FROM),
+            TAG_FROM_ID     => Some(TAG_FROM),
+            TAG_TO_ID       => Some(TAG_TO),
+            _ => None,
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+//  WireEdge — compact on-disk edge encoding (DataFileEnvelope v >= 2)
+//  CBOR (sized arrays, first element is the discriminator tag):
+//      SameFile     : [0, edgeTypeId, offset]
+//      CrossFile    : [1, edgeTypeId, fileOrdinal, offset]
+//      External     : [2, edgeTypeId, gitoidStr]
+//      UnknownType  : [3, edgeTypeStr, gitoidStr]
+// ─────────────────────────────────────────────────────────────────────────
+
+/// An edge as it appears on disk in v3 DataFiles. See goatrodeo's
+/// `io.spicelabs.goatrodeo.omnibor.WireEdge` for the authoritative
+/// description of each variant.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(untagged)]
+pub enum WireEdge {
+    SameFile { edge_type: u8, offset: u64 },
+    CrossFile { edge_type: u8, file_ordinal: u8, offset: u64 },
+    External { edge_type: u8, target: String },
+    UnknownType { edge_type: String, target: String },
+}
+
+impl<'de> Deserialize<'de> for WireEdge {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct WireEdgeVisitor;
+        impl<'de> serde::de::Visitor<'de> for WireEdgeVisitor {
+            type Value = WireEdge;
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a WireEdge array")
+            }
+            fn visit_seq<A>(self, mut seq: A) -> Result<WireEdge, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let tag: u32 = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::missing_field("tag"))?;
+                let result = match tag {
+                    0 => {
+                        let et: u32 = seq
+                            .next_element()?
+                            .ok_or_else(|| serde::de::Error::missing_field("edge_type"))?;
+                        let offset: u64 = seq
+                            .next_element()?
+                            .ok_or_else(|| serde::de::Error::missing_field("offset"))?;
+                        WireEdge::SameFile {
+                            edge_type: et as u8,
+                            offset,
+                        }
+                    }
+                    1 => {
+                        let et: u32 = seq
+                            .next_element()?
+                            .ok_or_else(|| serde::de::Error::missing_field("edge_type"))?;
+                        let fo: u32 = seq
+                            .next_element()?
+                            .ok_or_else(|| serde::de::Error::missing_field("file_ordinal"))?;
+                        let offset: u64 = seq
+                            .next_element()?
+                            .ok_or_else(|| serde::de::Error::missing_field("offset"))?;
+                        WireEdge::CrossFile {
+                            edge_type: et as u8,
+                            file_ordinal: fo as u8,
+                            offset,
+                        }
+                    }
+                    2 => {
+                        let et: u32 = seq
+                            .next_element()?
+                            .ok_or_else(|| serde::de::Error::missing_field("edge_type"))?;
+                        let target: String = seq
+                            .next_element()?
+                            .ok_or_else(|| serde::de::Error::missing_field("target"))?;
+                        WireEdge::External {
+                            edge_type: et as u8,
+                            target,
+                        }
+                    }
+                    3 => {
+                        let et: String = seq
+                            .next_element()?
+                            .ok_or_else(|| serde::de::Error::missing_field("edge_type"))?;
+                        let target: String = seq
+                            .next_element()?
+                            .ok_or_else(|| serde::de::Error::missing_field("target"))?;
+                        WireEdge::UnknownType {
+                            edge_type: et,
+                            target,
+                        }
+                    }
+                    other => {
+                        return Err(serde::de::Error::custom(format!(
+                            "Unknown WireEdge tag: {}",
+                            other
+                        )));
+                    }
+                };
+                // Drain to None. Goatrodeo's WireEdge encoder uses Borer's
+                // indefinite-length CBOR array form (`writeArrayOpen(n) …
+                // writeArrayClose()`), which emits a `0xFF` break marker
+                // after the elements. serde_cbor's SeqAccess expects
+                // `next_element` to be called until it returns `None` so
+                // that the break is consumed; returning from `visit_seq`
+                // early leaves the byte cursor pointing at the break,
+                // misaligning the outer Vec<WireEdge>'s SeqAccess. For
+                // hypothetical sized-array encoders this loop is a no-op
+                // (the first iteration returns `None` immediately).
+                while seq
+                    .next_element::<serde::de::IgnoredAny>()?
+                    .is_some()
+                {}
+                Ok(result)
+            }
+        }
+        deserializer.deserialize_seq(WireEdgeVisitor)
+    }
+}
+
+/// The on-disk shape of an Item under DataFileEnvelope v >= 2 — a thin
+/// mirror of [`Item`] but with `connections` carrying [`WireEdge`]
+/// values that still need to be resolved against the cluster's
+/// `(file_ordinal, offset) -> identifier` map.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct WireItem {
+    pub identifier: String,
+    pub connections: Vec<WireEdge>,
+    pub body_mime_type: Option<String>,
+    pub body: Option<Value>,
+}
+
 impl EdgeType for String {
     fn is_alias_from(&self) -> bool {
         self == ALIAS_FROM

--- a/src/rodeo/cluster.rs
+++ b/src/rodeo/cluster.rs
@@ -42,7 +42,8 @@ use std::collections::BTreeMap;
 /// cluster file (after the magic number and length prefix).
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ClusterFileEnvelope {
-    /// File format version (currently 3)
+    /// File format version (3 = legacy with per-DataFile aliasMap, 4 =
+    /// cluster-wide alias-map sidecar referenced by [`Self::alias_map_file`])
     pub version: u32,
 
     /// Magic number for file type validation (should be `ClusterFileMagicNumber`)
@@ -56,6 +57,14 @@ pub struct ClusterFileEnvelope {
 
     /// Arbitrary metadata (creation time, source info, build details, etc.)
     pub info: BTreeMap<String, String>,
+
+    /// SHA256-derived hash (truncated to u64) of the cluster-wide
+    /// alias-map sidecar file (`<hash>.gra`), if one was written. v3
+    /// envelopes omit the field; v4 envelopes set it to `Some(_)` when
+    /// the cluster has any aliases and `None` (encoded as CBOR null)
+    /// when it has none.
+    #[serde(default, rename = "alias_map_file")]
+    pub alias_map_file: Option<u64>,
 }
 
 /// Magic number identifying cluster (.grc) files: 0xba4a4a ("Banana")
@@ -65,14 +74,26 @@ pub struct ClusterFileEnvelope {
 #[allow(non_upper_case_globals)]
 pub const ClusterFileMagicNumber: u32 = 0xba4a4a; // Banana
 
-/// Minimum supported cluster file format version.
+/// Magic number identifying alias-map sidecar (.gra) files: 0x0a11a5ed ("Aliased").
 ///
-/// Files with versions below this cannot be read by this version of BigTent.
+/// Written by goatrodeo's v4 writer when the cluster's alias map is
+/// non-empty. The file's CBOR payload is a `BTreeMap<String,
+/// BTreeSet<String>>` mapping canonical identifiers to their alternates.
+#[allow(non_upper_case_globals)]
+pub const AliasMapFileMagicNumber: u32 = 0x0a11a5ed; // Aliased
+
+/// Lowest supported cluster file format version. v3 is accepted for
+/// backward compatibility (alias map in DataFile envelope, broken at
+/// scale); v4 is preferred (alias map in sidecar).
 #[allow(non_upper_case_globals)]
 pub const MinClusterVersion: u32 = 3;
 
+/// Highest supported cluster file format version.
+#[allow(non_upper_case_globals)]
+pub const MaxClusterVersion: u32 = 4;
+
 /// Current cluster file format version used when writing new clusters.
-pub const CLUSTER_VERSION: u32 = MinClusterVersion;
+pub const CLUSTER_VERSION: u32 = MaxClusterVersion;
 
 impl ClusterFileEnvelope {
     pub fn validate(&self) -> Result<()> {
@@ -80,11 +101,12 @@ impl ClusterFileEnvelope {
             bail!("Loaded a cluster with an invalid magic number: {:?}", self);
         }
 
-        if self.version != MinClusterVersion {
+        if self.version < MinClusterVersion || self.version > MaxClusterVersion {
             bail!(
-                "Loaded a Cluster with version {} but this code only supports version {} Clusters",
+                "Loaded a Cluster with version {} but this code only supports versions {}..={} Clusters",
                 self.version,
-                MinClusterVersion
+                MinClusterVersion,
+                MaxClusterVersion
             );
         }
 

--- a/src/rodeo/data.rs
+++ b/src/rodeo/data.rs
@@ -34,7 +34,7 @@
 //! loading the entire file into memory.
 
 use crate::{
-    item::Item,
+    item::{Item, WireItem},
     util::{read_cbor_sync, read_len_and_cbor_sync, read_u32_sync},
 };
 use anyhow::{Result, bail};
@@ -54,7 +54,8 @@ use super::goat::GoatRodeoCluster;
 /// Metadata envelope stored at the beginning of .grd data files.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct DataFileEnvelope {
-    /// File format version
+    /// File format version. v1 stored connections as `(String, String)`
+    /// tuples directly; v2 switched to the streamed `WireEdge` encoding.
     pub version: u32,
 
     /// Magic number for validation (should be `DataFileMagicNumber`)
@@ -82,6 +83,12 @@ pub struct DataFile {
     pub envelope: DataFileEnvelope,
     pub file: Arc<Mmap>,
     pub data_offset: usize,
+    /// Position of this DataFile in the cluster envelope's `data_files`
+    /// vector. Used to resolve v3 [`crate::item::WireEdge`] back-references.
+    /// Saturates at [`u8::MAX`] for clusters with more than 128
+    /// DataFiles — past that, cross-file edges are written as
+    /// [`crate::item::WireEdge::External`] by goatrodeo.
+    pub file_ordinal: u8,
 }
 
 pub const GOAT_RODEO_DATA_FILE_SUFFIX: &str = "grd";
@@ -89,7 +96,7 @@ pub const GOAT_RODEO_INDEX_FILE_SUFFIX: &str = "gri";
 pub const GOAT_RODEO_CLUSTER_FILE_SUFFIX: &str = "grc";
 
 impl DataFile {
-    pub async fn new(dir: &PathBuf, hash: u64) -> Result<DataFile> {
+    pub async fn new(dir: &PathBuf, hash: u64, file_ordinal: u8) -> Result<DataFile> {
         let mut data_file = GoatRodeoCluster::find_data_or_index_file_from_sha256(
             dir,
             hash,
@@ -120,14 +127,35 @@ impl DataFile {
             envelope: env,
             file: Arc::new(mmap),
             data_offset: cur_pos as usize,
+            file_ordinal,
         })
     }
 
-    /// read the item. This is a mixture of synchronous and async code. Why?
+    /// Read an Item at the given byte offset in this data file.
+    ///
+    /// For envelopes at version 1 the legacy CBOR `Item` codec is used.
+    /// For version >= 2 the on-disk form is the streamed [`WireItem`]
+    /// shape — callers (in `goat.rs`) handle WireEdge resolution and
+    /// alias:from synthesis against the cluster state and assemble the
+    /// final [`Item`].
+    ///
+    /// This is a mixture of synchronous and async code. Why?
     /// Turns out the async BufReader is freakin' slow, so we're doing synchronous
     /// BufReader. Ideally, we'd put this on a blocking Tokio thread, but, sigh
     /// async closures are not in mainline Rust right now, so "no thread-friendly soup for you!"
     pub fn read_item_at(&self, pos: usize) -> Option<Item> {
+        if self.envelope.version >= 2 {
+            // v3 callers should be using `read_wire_item_at` and
+            // resolving against the cluster-level back-reference map.
+            // We don't have access to that map here, so we surface an
+            // error via the existing `None`-on-failure contract.
+            error!(
+                "DataFile::read_item_at called on v{} file at offset {} without a cluster resolver — \
+                 use GoatRodeoCluster::item_for_file_and_offset for v >= 2 data",
+                self.envelope.version, pos
+            );
+            return None;
+        }
         let mut my_reader: &[u8] = &self.file[pos..];
 
         let item_len = match read_u32_sync(&mut my_reader) {
@@ -145,6 +173,37 @@ impl DataFile {
             }
         };
         Some(item)
+    }
+
+    /// Read a [`WireItem`] from this v >= 2 data file. Returns `None`
+    /// for v1 files (callers should use [`read_item_at`] for those).
+    pub fn read_wire_item_at(&self, pos: usize) -> Option<WireItem> {
+        if self.envelope.version < 2 {
+            return None;
+        }
+        let mut my_reader: &[u8] = &self.file[pos..];
+        let item_len = match read_u32_sync(&mut my_reader) {
+            Ok(v) => v,
+            Err(e) => {
+                error!("Failed to read length at offset {} err {:?}", pos, e);
+                return None;
+            }
+        };
+        let wi = match read_cbor_sync::<WireItem, _>(&mut my_reader, item_len as usize) {
+            Ok(i) => i,
+            Err(e) => {
+                error!("Failed to read WireItem at offset {} error {:?}", pos, e);
+                return None;
+            }
+        };
+        Some(wi)
+    }
+
+    /// Read just the `identifier` of the v >= 2 item at this offset,
+    /// without paying the cost of resolving its connections. Used for
+    /// lazily populating the cluster's back-reference cache.
+    pub fn read_identifier_at(&self, pos: usize) -> Option<String> {
+        self.read_wire_item_at(pos).map(|wi| wi.identifier)
     }
 }
 

--- a/src/rodeo/data.rs
+++ b/src/rodeo/data.rs
@@ -54,8 +54,16 @@ use super::goat::GoatRodeoCluster;
 /// Metadata envelope stored at the beginning of .grd data files.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct DataFileEnvelope {
-    /// File format version. v1 stored connections as `(String, String)`
-    /// tuples directly; v2 switched to the streamed `WireEdge` encoding.
+    /// File format version.
+    ///
+    /// - v1 stored connections as `(String, String)` tuples directly.
+    /// - v2 switched to the streamed `WireEdge` encoding.
+    /// - v3 added an `alias_map` field — withdrawn: the 16-bit
+    ///   envelope-length prefix overflows once the embedded alias map
+    ///   exceeds 64 KiB.
+    /// - v4 has no `alias_map` field; the alias map lives in a
+    ///   cluster-wide `.gra` sidecar referenced from the cluster
+    ///   envelope's `alias_map_file`.
     pub version: u32,
 
     /// Magic number for validation (should be `DataFileMagicNumber`)

--- a/src/rodeo/goat.rs
+++ b/src/rodeo/goat.rs
@@ -245,8 +245,19 @@ impl GoatRodeoTrait for GoatRodeoCluster {
     }
 
     fn item_for_identifier(&self, data: &str) -> Option<Item> {
-        let md5_hash = md5hash_str(data);
-        self.item_for_hash(md5_hash)
+        // Try the primary (binary Identifier form) hash first; fall back
+        // to the legacy canonical-string form for compatibility with v1
+        // clusters whose `.gri` keys predate the Identifier opaque type.
+        let primary = md5hash_str(data);
+        if let Some(item) = self.item_for_hash(primary) {
+            return Some(item);
+        }
+        let legacy = crate::util::md5hash_str_canonical(data);
+        if legacy != primary {
+            self.item_for_hash(legacy)
+        } else {
+            None
+        }
     }
 
     fn item_for_hash(&self, hash: MD5Hash) -> Option<Item> {
@@ -826,8 +837,16 @@ impl GoatRodeoCluster {
     /// index. This is a fast operation as it's just a binary search of the index which is
     /// in memory
     pub fn identifier_to_item_offset(&self, identifier: &str) -> Option<ItemOffset> {
-        let hash = md5hash_str(identifier);
-        self.hash_to_item_offset(hash)
+        let primary = md5hash_str(identifier);
+        if let Some(eo) = self.hash_to_item_offset(primary) {
+            return Some(eo);
+        }
+        let legacy = crate::util::md5hash_str_canonical(identifier);
+        if legacy != primary {
+            self.hash_to_item_offset(legacy)
+        } else {
+            None
+        }
     }
 
     /// from a hash, find the ItemOffset

--- a/src/rodeo/goat.rs
+++ b/src/rodeo/goat.rs
@@ -192,6 +192,17 @@ pub struct GoatRodeoCluster {
     /// `OnceLock` gives us blocking lazy initialisation that is safe to
     /// call from synchronous hot paths.
     inverse_edge_index: Arc<OnceLock<InverseEdgeIndex>>,
+
+    /// Cluster-wide alias map, loaded from the `<hash>.gra` sidecar
+    /// file referenced by `ClusterFileEnvelope.alias_map_file` when
+    /// the cluster is opened. Empty for v3 clusters and for v4
+    /// clusters with `alias_map_file: None`.
+    ///
+    /// Maps `canonical_identifier -> set of alternate identifiers`.
+    /// Consulted on the v3/v4 item-read path to synthesise the
+    /// `alias:from` edges that goatrodeo's v4 writer strips from the
+    /// on-disk Item bytes.
+    alias_map: std::collections::BTreeMap<String, std::collections::BTreeSet<String>>,
 }
 
 /// `(forward_edge_type, target_identifier) -> { source_identifier }`.
@@ -524,6 +535,14 @@ impl GoatRodeoCluster {
             });
         }
 
+        // Load the cluster-wide alias map sidecar if the envelope
+        // references one. v3 clusters don't set this field; v4 clusters
+        // set it to Some(hash) when the cluster has any aliases.
+        let alias_map = match env.alias_map_file {
+            Some(hash) => Self::load_alias_map_file(&parent, hash).await?,
+            None => std::collections::BTreeMap::new(),
+        };
+
         info!("New cluster load time {:?}", start.elapsed());
 
         let ret = Arc::new(GoatRodeoCluster {
@@ -546,6 +565,7 @@ impl GoatRodeoCluster {
             directory: parent,
             index_offset: IndexOffset::from_index_files(&index_vec),
             inverse_edge_index: Arc::new(OnceLock::new()),
+            alias_map,
         });
 
         ret.clone().kick_off_index_build_if_load_true().await;
@@ -851,13 +871,16 @@ impl GoatRodeoCluster {
                     return df.read_item_at(offset);
                 }
                 // v >= 2 path: WireItem -> resolve back-references -> Item,
-                // augmenting with the inverse halves of forward content
-                // edges via the cluster's lazy inverse-edge index.
+                // synthesising alias:from edges from the cluster's
+                // alias map, then augmenting with the inverse halves of
+                // forward content edges via the lazy inverse-edge index.
                 let wi = df.read_wire_item_at(offset)?;
                 let connections = self.resolve_wire_edges(
                     wi.connections,
                     df.file_ordinal,
                 );
+                let connections =
+                    self.synthesise_alias_from(connections, &wi.identifier);
                 let connections =
                     self.synthesise_inverse_content_edges(connections, &wi.identifier);
                 Some(Item {
@@ -1033,6 +1056,55 @@ impl GoatRodeoCluster {
             .get(file_ordinal as usize)?;
         let df = self.data_files.get(&file_hash)?;
         df.read_identifier_at(offset as usize)
+    }
+
+    /// If this canonical's identifier appears as a key in the cluster's
+    /// `alias_map`, synthesise an `alias:from` edge for each alternate.
+    /// This restores byte-for-byte parity with the pre-collapse
+    /// in-memory shape that v1 readers saw, hiding the alias-table
+    /// optimisation from callers.
+    fn synthesise_alias_from(
+        &self,
+        mut connections: std::collections::BTreeSet<crate::item::Edge>,
+        identifier: &str,
+    ) -> std::collections::BTreeSet<crate::item::Edge> {
+        use crate::item::ALIAS_FROM;
+        if let Some(alts) = self.alias_map.get(identifier) {
+            for alt in alts {
+                connections.insert((ALIAS_FROM.to_string(), alt.clone()));
+            }
+        }
+        connections
+    }
+
+    /// Read and decode a `<hash>.gra` alias-map sidecar file produced
+    /// by goatrodeo's v4 writer. Layout: a 4-byte magic
+    /// ([`AliasMapFileMagicNumber`]) followed by a single CBOR map (no
+    /// length prefix — the map is self-delimiting and consumes the
+    /// remainder of the file).
+    async fn load_alias_map_file(
+        dir: &PathBuf,
+        hash: u64,
+    ) -> Result<std::collections::BTreeMap<String, std::collections::BTreeSet<String>>> {
+        use crate::rodeo::cluster::AliasMapFileMagicNumber;
+        use std::io::Read;
+
+        let mut file =
+            GoatRodeoCluster::find_data_or_index_file_from_sha256(dir, hash, "gra").await?;
+        let magic = crate::util::read_u32_sync(&mut file)?;
+        if magic != AliasMapFileMagicNumber {
+            bail!(
+                "Unexpected magic number {:x}, expecting {:x} for alias-map file {:016x}.gra",
+                magic,
+                AliasMapFileMagicNumber,
+                hash
+            );
+        }
+        let mut buf = Vec::new();
+        file.read_to_end(&mut buf)?;
+        let map: std::collections::BTreeMap<String, std::collections::BTreeSet<String>> =
+            serde_cbor::from_slice(&buf)?;
+        Ok(map)
     }
 
     pub fn item_from_index_loc(&self, index_loc: &ItemLoc) -> Option<Item> {

--- a/src/rodeo/goat.rs
+++ b/src/rodeo/goat.rs
@@ -45,7 +45,7 @@ use std::{
     fs::File,
     ops::Deref,
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, OnceLock},
     time::Instant,
 };
 use thousands::Separable;
@@ -178,7 +178,28 @@ pub struct GoatRodeoCluster {
 
     /// Whether to pre-load index into memory
     load_index: bool,
+
+    /// Lazy per-cluster inverse-edge index, populated by streaming
+    /// every v >= 2 DataFile on first request. Maps
+    /// `(forward_edge_type, target_identifier) -> { source_identifier }`
+    /// for the forward content edges (`contained:up`, `build:down`).
+    ///
+    /// Goatrodeo v3 writers drop the inverse halves of these edges
+    /// (`contained:down`, `build:up`) from items on disk; this index
+    /// lets bigtent transparently synthesise them on read so traversal
+    /// callers don't need to change.
+    ///
+    /// `OnceLock` gives us blocking lazy initialisation that is safe to
+    /// call from synchronous hot paths.
+    inverse_edge_index: Arc<OnceLock<InverseEdgeIndex>>,
 }
+
+/// `(forward_edge_type, target_identifier) -> { source_identifier }`.
+///
+/// Built by walking every v >= 2 DataFile sequentially and recording
+/// each item's outgoing `contained:up` and `build:down` edges keyed
+/// against the target identifier.
+type InverseEdgeIndex = HashMap<(String, String), HashSet<String>>;
 
 impl GoatRodeoTrait for GoatRodeoCluster {
     /// create a stream for the flattened items. If any of the `gitoids` cannot
@@ -524,6 +545,7 @@ impl GoatRodeoCluster {
             load_index,
             directory: parent,
             index_offset: IndexOffset::from_index_files(&index_vec),
+            inverse_edge_index: Arc::new(OnceLock::new()),
         });
 
         ret.clone().kick_off_index_build_if_load_true().await;
@@ -824,14 +846,20 @@ impl GoatRodeoCluster {
         match data_file {
             Some(df) => {
                 if df.envelope.version < 2 {
+                    // v1 items already carry their inverse edges
+                    // verbatim — no augmentation needed.
                     return df.read_item_at(offset);
                 }
-                // v >= 2 path: WireItem -> resolve back-references -> Item.
+                // v >= 2 path: WireItem -> resolve back-references -> Item,
+                // augmenting with the inverse halves of forward content
+                // edges via the cluster's lazy inverse-edge index.
                 let wi = df.read_wire_item_at(offset)?;
                 let connections = self.resolve_wire_edges(
                     wi.connections,
                     df.file_ordinal,
                 );
+                let connections =
+                    self.synthesise_inverse_content_edges(connections, &wi.identifier);
                 Some(Item {
                     identifier: wi.identifier,
                     connections,
@@ -846,6 +874,96 @@ impl GoatRodeoCluster {
                 );
             }
         }
+    }
+
+    /// Get the per-cluster inverse-edge index, building it on demand.
+    ///
+    /// The build walks every v >= 2 DataFile sequentially (using the
+    /// length-prefixed frame format) and records each item's outgoing
+    /// `contained:up` and `build:down` edges keyed against the target
+    /// identifier. For v1 DataFiles nothing is recorded — v1 items
+    /// already carry their inverse edges on disk so callers don't need
+    /// to consult this index.
+    fn get_or_build_inverse_index(&self) -> &InverseEdgeIndex {
+        self.inverse_edge_index
+            .get_or_init(|| self.build_inverse_index())
+    }
+
+    fn build_inverse_index(&self) -> InverseEdgeIndex {
+        use crate::item::{BUILT_FROM, CONTAINED_BY};
+        let mut idx: InverseEdgeIndex = HashMap::new();
+
+        for df in self.data_files.values() {
+            if df.envelope.version < 2 {
+                continue;
+            }
+            let mut pos = df.data_offset;
+            let file_len = df.file.len();
+            loop {
+                if pos + 4 > file_len {
+                    break;
+                }
+                let len_bytes: [u8; 4] = match df.file[pos..pos + 4].try_into() {
+                    Ok(b) => b,
+                    Err(_) => break,
+                };
+                let item_len = u32::from_be_bytes(len_bytes);
+                if item_len == 0xFFFF_FFFF {
+                    // EOF sentinel (-1 as u32, big-endian).
+                    break;
+                }
+                let item_len = item_len as usize;
+                if pos + 4 + item_len > file_len {
+                    break;
+                }
+                let frame_start = pos;
+                let wi = match df.read_wire_item_at(frame_start) {
+                    Some(wi) => wi,
+                    None => break,
+                };
+                // Resolve WireEdges back to (et, target) edges so we
+                // see the actual target identifiers (not raw offsets).
+                let connections =
+                    self.resolve_wire_edges(wi.connections, df.file_ordinal);
+                for (et, target) in connections {
+                    if et == CONTAINED_BY || et == BUILT_FROM {
+                        idx.entry((et, target))
+                            .or_insert_with(HashSet::new)
+                            .insert(wi.identifier.clone());
+                    }
+                }
+                pos = frame_start + 4 + item_len;
+            }
+        }
+        idx
+    }
+
+    /// Augment a v >= 2 Item's connections with the inverse halves of
+    /// forward content edges (`contained:down`, `build:up`) by
+    /// consulting the cluster's lazy inverse-edge index. Idempotent for
+    /// v1-style data where the inverse edges may already be present.
+    fn synthesise_inverse_content_edges(
+        &self,
+        mut connections: std::collections::BTreeSet<crate::item::Edge>,
+        identifier: &str,
+    ) -> std::collections::BTreeSet<crate::item::Edge> {
+        use crate::item::{BUILDS_TO, BUILT_FROM, CONTAINED_BY, CONTAINS};
+        let idx = self.get_or_build_inverse_index();
+        if let Some(sources) =
+            idx.get(&(CONTAINED_BY.to_string(), identifier.to_string()))
+        {
+            for src in sources {
+                connections.insert((CONTAINS.to_string(), src.clone()));
+            }
+        }
+        if let Some(sources) =
+            idx.get(&(BUILT_FROM.to_string(), identifier.to_string()))
+        {
+            for src in sources {
+                connections.insert((BUILDS_TO.to_string(), src.clone()));
+            }
+        }
+        connections
     }
 
     /// Resolve a vector of [`crate::item::WireEdge`]s into the concrete

--- a/src/rodeo/goat.rs
+++ b/src/rodeo/goat.rs
@@ -467,8 +467,18 @@ impl GoatRodeoCluster {
         }
 
         let mut data_files = HashMap::new();
-        for data_file in &env.data_files {
-            let the_file = Arc::new(DataFile::new(&parent, *data_file).await?);
+        for (i, data_file) in env.data_files.iter().enumerate() {
+            // Saturate the ordinal at u8::MAX, matching goatrodeo's
+            // WriteContext behaviour for clusters with more than 128
+            // DataFiles. Beyond that bigtent will see all cross-file
+            // edges as `External` instead of `CrossFile`, which still
+            // round-trips correctly (just with a larger encoding).
+            let ordinal: u8 = if i > u8::MAX as usize {
+                u8::MAX
+            } else {
+                i as u8
+            };
+            let the_file = Arc::new(DataFile::new(&parent, *data_file, ordinal).await?);
             data_files.insert(*data_file, the_file);
         }
 
@@ -813,9 +823,21 @@ impl GoatRodeoCluster {
         let data_file = data_files.get(&file_hash);
         match data_file {
             Some(df) => {
-                let item = df.read_item_at(offset)?;
-
-                Some(item)
+                if df.envelope.version < 2 {
+                    return df.read_item_at(offset);
+                }
+                // v >= 2 path: WireItem -> resolve back-references -> Item.
+                let wi = df.read_wire_item_at(offset)?;
+                let connections = self.resolve_wire_edges(
+                    wi.connections,
+                    df.file_ordinal,
+                );
+                Some(Item {
+                    identifier: wi.identifier,
+                    connections,
+                    body_mime_type: wi.body_mime_type,
+                    body: wi.body,
+                })
             }
             None => {
                 panic!(
@@ -824,6 +846,75 @@ impl GoatRodeoCluster {
                 );
             }
         }
+    }
+
+    /// Resolve a vector of [`crate::item::WireEdge`]s into the concrete
+    /// `(edgeType, targetIdentifier)` edges that the rest of bigtent
+    /// expects in [`Item::connections`].
+    ///
+    /// For `SameFile(off)` we look up the identifier at `(ord, off)`
+    /// in the current data file. For `CrossFile(fo, off)` we resolve
+    /// against the DataFile with that ordinal in
+    /// `self.envelope.data_files`. Unknown byte IDs in `External`
+    /// edges fall back to logging and being dropped — they shouldn't
+    /// appear under any released version of the wire format.
+    fn resolve_wire_edges(
+        &self,
+        wire_edges: Vec<crate::item::WireEdge>,
+        current_ordinal: u8,
+    ) -> std::collections::BTreeSet<crate::item::Edge> {
+        use crate::item::{WireEdge, edge_type_id};
+        let mut out = std::collections::BTreeSet::new();
+        for we in wire_edges {
+            match we {
+                WireEdge::SameFile { edge_type, offset } => {
+                    let et = match edge_type_id::to_str(edge_type) {
+                        Some(s) => s,
+                        None => continue,
+                    };
+                    if let Some(target) =
+                        self.identifier_at(current_ordinal, offset)
+                    {
+                        out.insert((et.to_string(), target));
+                    }
+                }
+                WireEdge::CrossFile {
+                    edge_type,
+                    file_ordinal,
+                    offset,
+                } => {
+                    let et = match edge_type_id::to_str(edge_type) {
+                        Some(s) => s,
+                        None => continue,
+                    };
+                    if let Some(target) = self.identifier_at(file_ordinal, offset)
+                    {
+                        out.insert((et.to_string(), target));
+                    }
+                }
+                WireEdge::External { edge_type, target } => {
+                    if let Some(et) = edge_type_id::to_str(edge_type) {
+                        out.insert((et.to_string(), target));
+                    }
+                }
+                WireEdge::UnknownType { edge_type, target } => {
+                    out.insert((edge_type, target));
+                }
+            }
+        }
+        out
+    }
+
+    /// Read the identifier of the item stored at `(file_ordinal, offset)`
+    /// in this cluster. Returns `None` if no DataFile with that ordinal
+    /// exists or the bytes at the offset can't be decoded.
+    fn identifier_at(&self, file_ordinal: u8, offset: u64) -> Option<String> {
+        let file_hash = *self
+            .envelope
+            .data_files
+            .get(file_ordinal as usize)?;
+        let df = self.data_files.get(&file_hash)?;
+        df.read_identifier_at(offset as usize)
     }
 
     pub fn item_from_index_loc(&self, index_loc: &ItemLoc) -> Option<Item> {

--- a/src/rodeo/goat.rs
+++ b/src/rodeo/goat.rs
@@ -203,6 +203,18 @@ pub struct GoatRodeoCluster {
     /// `alias:from` edges that goatrodeo's v4 writer strips from the
     /// on-disk Item bytes.
     alias_map: std::collections::BTreeMap<String, std::collections::BTreeSet<String>>,
+
+    /// Lazy inverse of [`Self::alias_map`] — maps each alternate
+    /// identifier to its canonical. Populated on first use by
+    /// `alias_inverse_map()`.
+    ///
+    /// Used by `item_for_identifier` (and friends) to restore the v1
+    /// "look up by alias" behaviour against v4 clusters: in v1 each
+    /// alternate had its own pointer Item in the `.gri` with a single
+    /// `alias:to` edge; in v4 those Items don't exist on disk, only as
+    /// entries in this map. On lookup miss we synthesise the same
+    /// pointer Item from the inverse map.
+    alias_inverse_map: Arc<OnceLock<HashMap<String, String>>>,
 }
 
 /// `(forward_edge_type, target_identifier) -> { source_identifier }`.
@@ -254,10 +266,30 @@ impl GoatRodeoTrait for GoatRodeoCluster {
         }
         let legacy = crate::util::md5hash_str_canonical(data);
         if legacy != primary {
-            self.item_for_hash(legacy)
-        } else {
-            None
+            if let Some(item) = self.item_for_hash(legacy) {
+                return Some(item);
+            }
         }
+        // v4 clusters strip alternate-form identifiers from the .grd
+        // (they survive only as entries in the cluster's .gra sidecar).
+        // For v1 compatibility, when the index miss happens but the
+        // identifier is a known alternate, synthesise the pointer Item
+        // that v1 would have stored on disk: identifier-as-given,
+        // `connections: [(alias:to, canonical)]`, no body. Downstream
+        // helpers (`antialias_for`, `impl_stream_flattened_items`,
+        // `impl_north_send`) already know how to chase `alias:to`.
+        if let Some(canonical) = self.alias_inverse_map().get(data) {
+            use crate::item::ALIAS_TO;
+            let mut connections = std::collections::BTreeSet::new();
+            connections.insert((ALIAS_TO.to_string(), canonical.clone()));
+            return Some(Item {
+                identifier: data.to_string(),
+                connections,
+                body_mime_type: None,
+                body: None,
+            });
+        }
+        None
     }
 
     fn item_for_hash(&self, hash: MD5Hash) -> Option<Item> {
@@ -273,6 +305,7 @@ impl GoatRodeoTrait for GoatRodeoCluster {
 
     fn has_identifier(&self, identifier: &str) -> bool {
         self.identifier_to_item_offset(identifier).is_some()
+            || self.alias_inverse_map().contains_key(identifier)
     }
 
     fn is_empty(&self) -> bool {
@@ -577,6 +610,7 @@ impl GoatRodeoCluster {
             index_offset: IndexOffset::from_index_files(&index_vec),
             inverse_edge_index: Arc::new(OnceLock::new()),
             alias_map,
+            alias_inverse_map: Arc::new(OnceLock::new()),
         });
 
         ret.clone().kick_off_index_build_if_load_true().await;
@@ -1096,6 +1130,26 @@ impl GoatRodeoCluster {
         connections
     }
 
+    /// Inverse of [`Self::alias_map`] — `alternate → canonical`.
+    /// Built lazily on first request from the sidecar map.
+    ///
+    /// Used by the v1-compat path in `item_for_identifier`: when an
+    /// alternate-form identifier misses the `.gri` index, we synthesise
+    /// the pointer Item that v1 would have returned (a single
+    /// `alias:to → canonical` edge, no body). Empty for v1 clusters,
+    /// so the new code path is dead for them.
+    fn alias_inverse_map(&self) -> &HashMap<String, String> {
+        self.alias_inverse_map.get_or_init(|| {
+            let mut out = HashMap::new();
+            for (canon, alts) in &self.alias_map {
+                for alt in alts {
+                    out.insert(alt.clone(), canon.clone());
+                }
+            }
+            out
+        })
+    }
+
     /// Read and decode a `<hash>.gra` alias-map sidecar file produced
     /// by goatrodeo's v4 writer. Layout: a 4-byte magic
     /// ([`AliasMapFileMagicNumber`]) followed by a single CBOR map (no
@@ -1129,6 +1183,103 @@ impl GoatRodeoCluster {
     pub fn item_from_index_loc(&self, index_loc: &ItemLoc) -> Option<Item> {
         self.item_for_file_and_offset(index_loc.get_file_hash(), index_loc.get_offset())
     }
+}
+
+/// On v4 clusters, alternate-form identifiers are not items in the
+/// `.gri`; they live only as entries in the `.gra` sidecar. Verify
+/// that bigtent restores v1's "look up by alias" behaviour by
+/// synthesising the pointer Item from the sidecar.
+///
+/// The test punts unless `../goatrodeo/res_for_big_tent/` is populated.
+/// It picks any canonical that has at least one alternate in the
+/// alias map, then for each alternate confirms:
+///   1. `item_for_identifier(alternate)` returns a synthesised stub
+///      with `connections = [(alias:to, canonical)]`, no body.
+///   2. `has_identifier(alternate)` returns true.
+///   3. `antialias_for(alternate)` returns the canonical's full Item
+///      (with body and full connection set).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_alias_lookup_through_sidecar() {
+    use crate::item::{ALIAS_TO, ALIAS_FROM};
+    use std::path::PathBuf;
+    use crate::rodeo::goat_trait::GoatRodeoTrait;
+    let goat_rodeo_test_data: PathBuf = "../goatrodeo/res_for_big_tent/".into();
+    if !goat_rodeo_test_data.is_dir() {
+        return;
+    }
+    let mut files = GoatRodeoCluster::cluster_files_in_dir(
+        "../goatrodeo/res_for_big_tent/".into(),
+        false,
+        vec![],
+    )
+    .await
+    .expect("Should read cluster files");
+    let Some(cluster) = files.pop() else {
+        return;
+    };
+    // Only v4 clusters have a non-empty alias map.
+    let Some((canonical, alts)) = cluster
+        .alias_map
+        .iter()
+        .find(|(_, alts)| !alts.is_empty())
+    else {
+        eprintln!("No aliases in cluster — skipping (cluster is likely v1)");
+        return;
+    };
+    let canonical = canonical.clone();
+    let alt = alts.iter().next().unwrap().clone();
+
+    // 1. /item/<alt> synthesises the stub.
+    let stub = cluster
+        .item_for_identifier(&alt)
+        .expect("alternate must resolve via the sidecar fallback");
+    assert_eq!(stub.identifier, alt);
+    assert!(stub.body.is_none(), "stub item should have no body");
+    assert!(
+        stub.body_mime_type.is_none(),
+        "stub item should have no body_mime_type"
+    );
+    assert_eq!(
+        stub.connections.len(),
+        1,
+        "stub should have exactly one alias:to edge, got {:?}",
+        stub.connections
+    );
+    let (et, target) = stub.connections.iter().next().unwrap();
+    assert_eq!(et, ALIAS_TO);
+    assert_eq!(target, &canonical);
+
+    // 2. /has/<alt>
+    assert!(
+        cluster.has_identifier(&alt),
+        "has_identifier should return true for an alternate in the alias map"
+    );
+
+    // 3. /aa/<alt> resolves through alias:to to the canonical's full Item.
+    let canon_via_alt = cluster
+        .clone()
+        .antialias_for(&alt)
+        .expect("antialias_for must follow alias:to to the canonical");
+    let canon_direct = cluster
+        .item_for_identifier(&canonical)
+        .expect("canonical must be directly resolvable");
+    assert_eq!(
+        canon_via_alt.identifier, canon_direct.identifier,
+        "antialiased identifier should be the canonical"
+    );
+    assert_eq!(
+        canon_via_alt.body, canon_direct.body,
+        "antialiased body should match canonical's"
+    );
+    // The canonical's connections include the synthesised alias:from edges,
+    // one per alternate.
+    assert!(
+        canon_direct
+            .connections
+            .iter()
+            .any(|(et, target)| et == ALIAS_FROM && target == &alt),
+        "canonical must expose an alias:from edge back to the alternate"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]

--- a/src/rodeo/writer.rs
+++ b/src/rodeo/writer.rs
@@ -208,6 +208,11 @@ impl ClusterWriter {
                 info: BTreeMap::new(),
                 data_files: self.seen_data_files.lock().await.iter().copied().collect(),
                 index_files: self.index_files.lock().await.iter().copied().collect(),
+                // Bigtent's writer doesn't produce an alias map sidecar
+                // (it ships clusters built by goatrodeo); leave the
+                // reference unset so the cluster encodes as if it had
+                // no aliases.
+                alias_map_file: None,
             };
             write_envelope(cluster_writer, &cluster_env).await?;
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -138,14 +138,154 @@ pub fn millis_now() -> i64 {
         .as_millis() as i64
 }
 
-/// Compute MD5 hash of a string.
+/// Compute MD5 hash of a string for use as a primary `.gri` index key.
 ///
-/// Used for index key generation. Note: MD5 is used for lookup efficiency,
-/// not security. Data integrity uses SHA256.
+/// Goatrodeo's v4 writer (and BigTent, going forward) keys index entries
+/// by MD5 of the *binary* `Identifier` form (header byte + raw hash
+/// bytes for gitoid/raw-hash, header byte + UTF-8 bytes for
+/// PackageUrl/sentinel). See [`identifier_bytes`] for the layout.
+///
+/// MD5 is used for lookup efficiency, not security; data integrity
+/// uses SHA256.
 pub fn md5hash_str(st: &str) -> MD5Hash {
-    let res = md5::compute(st);
-
+    let bytes = identifier_bytes(st);
+    let res = md5::compute(&bytes);
     res.into()
+}
+
+/// Legacy MD5 hash form — MD5 of the canonical UTF-8 string.
+///
+/// Pre-v4 goatrodeo (and earlier BigTent writers) keyed `.gri` entries
+/// by this. Kept for backward-compatible lookups against existing v1
+/// clusters, used as a fallback when the primary [`md5hash_str`] lookup
+/// misses.
+pub fn md5hash_str_canonical(st: &str) -> MD5Hash {
+    let res = md5::compute(st);
+    res.into()
+}
+
+/// Encode a canonical-form identifier string into the binary representation
+/// that goatrodeo's `Identifier` opaque type stores on disk.
+///
+/// Layout — byte 0 packs the kind into the high nibble and a kind-specific
+/// sub-encoding into the low nibble:
+///
+/// ```text
+///   high nibble (bits 7..4)        low nibble (bits 3..0)
+///   0 = Gitoid                     (ObjectType.ordinal << 2) | HashAlgorithm.ordinal
+///   1 = RawHash                    RawHashAlgorithm.ordinal
+///   2 = PackageUrl                 0
+///   3 = Sentinel                   0
+/// ```
+///
+/// Bytes 1.. are the raw hash bytes (for Gitoid / RawHash) or the UTF-8
+/// bytes of the canonical text form (for PackageUrl / Sentinel).
+///
+/// Object-type ordinals: Blob=0, Tree=1, Commit=2, Tag=3.
+/// HashAlgorithm ordinals (Gitoid): Sha1=0, Sha256=1.
+/// RawHashAlgorithm ordinals: Md5=0, Sha1=1, Sha256=2, Sha512=3.
+///
+/// Falls back to the sentinel encoding for malformed gitoid / raw-hash
+/// strings, matching goatrodeo's tolerance for short test fixtures.
+pub fn identifier_bytes(canonical: &str) -> Vec<u8> {
+    const KIND_GITOID: u8 = 0;
+    const KIND_RAW_HASH: u8 = 1;
+    const KIND_PACKAGE_URL: u8 = 2;
+    const KIND_SENTINEL: u8 = 3;
+
+    fn header(kind: u8, sub: u8) -> u8 {
+        ((kind & 0xf) << 4) | (sub & 0xf)
+    }
+
+    fn sentinel(s: &str) -> Vec<u8> {
+        let utf8 = s.as_bytes();
+        let mut out = Vec::with_capacity(1 + utf8.len());
+        out.push(header(KIND_SENTINEL, 0));
+        out.extend_from_slice(utf8);
+        out
+    }
+
+    fn hex_to_bytes(hex: &str, out: &mut Vec<u8>) -> bool {
+        if !hex.len().is_multiple_of(2) {
+            return false;
+        }
+        for chunk in hex.as_bytes().chunks(2) {
+            let hi = match (chunk[0] as char).to_digit(16) {
+                Some(v) => v as u8,
+                None => return false,
+            };
+            let lo = match (chunk[1] as char).to_digit(16) {
+                Some(v) => v as u8,
+                None => return false,
+            };
+            out.push((hi << 4) | lo);
+        }
+        true
+    }
+
+    // gitoid:<objectType>:<algo>:<hex>
+    if let Some(rest) = canonical.strip_prefix("gitoid:") {
+        let parts: Vec<&str> = rest.splitn(3, ':').collect();
+        if parts.len() == 3 {
+            let object_ordinal: Option<u8> = match parts[0] {
+                "blob" => Some(0),
+                "tree" => Some(1),
+                "commit" => Some(2),
+                "tag" => Some(3),
+                _ => None,
+            };
+            let algo: Option<(u8, usize)> = match parts[1] {
+                "sha1" => Some((0, 20)),
+                "sha256" => Some((1, 32)),
+                _ => None,
+            };
+            if let (Some(obj), Some((algo_ord, byte_len))) = (object_ordinal, algo) {
+                if parts[2].len() == byte_len * 2 {
+                    let mut out = Vec::with_capacity(1 + byte_len);
+                    out.push(header(KIND_GITOID, ((obj & 0x3) << 2) | (algo_ord & 0x3)));
+                    if hex_to_bytes(parts[2], &mut out) {
+                        return out;
+                    }
+                }
+            }
+        }
+        return sentinel(canonical);
+    }
+
+    // pkg:...
+    if let Some(_rest) = canonical.strip_prefix("pkg:") {
+        let utf8 = canonical.as_bytes();
+        let mut out = Vec::with_capacity(1 + utf8.len());
+        out.push(header(KIND_PACKAGE_URL, 0));
+        out.extend_from_slice(utf8);
+        return out;
+    }
+
+    // <algo>:<hex>
+    let raw_algo: Option<(&str, u8, usize)> = if canonical.starts_with("md5:") {
+        Some(("md5:", 0, 16))
+    } else if canonical.starts_with("sha1:") {
+        Some(("sha1:", 1, 20))
+    } else if canonical.starts_with("sha256:") {
+        Some(("sha256:", 2, 32))
+    } else if canonical.starts_with("sha512:") {
+        Some(("sha512:", 3, 64))
+    } else {
+        None
+    };
+    if let Some((prefix, algo_ord, byte_len)) = raw_algo {
+        let hex = &canonical[prefix.len()..];
+        if hex.len() == byte_len * 2 {
+            let mut out = Vec::with_capacity(1 + byte_len);
+            out.push(header(KIND_RAW_HASH, algo_ord));
+            if hex_to_bytes(hex, &mut out) {
+                return out;
+            }
+        }
+        return sentinel(canonical);
+    }
+
+    sentinel(canonical)
 }
 
 /// Compute SHA256 hash of a byte slice.
@@ -158,6 +298,33 @@ pub fn sha256_for_slice(r: &[u8]) -> [u8; 32] {
     hasher.update(r);
 
     hasher.finalize().into()
+}
+
+#[test]
+fn test_md5hash_str_matches_goatrodeo_identifier_form() {
+    // Pinned against the index files goatrodeo's v4 writer produces.
+    // The MD5 keys cover the binary Identifier layout, not the canonical
+    // text form — see identifier_bytes for the layout.
+    let cases: &[(&str, &str)] = &[
+        (
+            "gitoid:blob:sha256:bac938b7bc5d3af6ffc1e83d3ae26219d10660315f6f5481d97251bbfc8560a6",
+            "d58fa99dbbb64eac9ed11ff56440cec2",
+        ),
+        (
+            "gitoid:blob:sha256:4ffa7795396697e3de38d20cae12be8d81b6da1cebb61c214a332747e726ba86",
+            "b68691f79d534a3086626d83e0675c97",
+        ),
+        ("tags", "7d71edd9af3c27c8fae771e8811d524e"),
+    ];
+    for (id, expected) in cases {
+        let bytes = md5hash_str(id);
+        let hex: String = bytes.iter().map(|b| format!("{:02x}", b)).collect();
+        assert_eq!(
+            hex, *expected,
+            "md5hash_str({}) produced {} but expected {}",
+            id, hex, expected
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Adds bigtent reader-side support for the more concise on-disk format that goatrodeo emits in [#264](https://github.com/spice-labs-inc/goatrodeo/pull/264). On the ADGTest corpus that PR shrinks a freshly-built cluster from ~887 MB to ~278 MB; this is what lets bigtent read it.

What the new format changes:

- **Streamed `WireEdge` encoding.** Connection edges in v ≥ 2 data files are discriminator-tagged (`SameFile`, `CrossFile`, `External`, `UnknownType`) rather than carrying full identifier strings; bigtent resolves them against the cluster on read.
- **Inverse content edges stripped on write.** Goatrodeo drops `contained:down` and `build:up` from items since they're the inverse halves of `contained:up` / `build:down`. Bigtent reconstructs them from a lazy cluster-level inverse-edge index so existing traversals (`/flatten`, `/north`, etc.) see the same `Item.connections` shape.
- **Alias map moved to a `.gra` sidecar (v4).** The earlier v3 attempt embedded the map inside `DataFileEnvelope`, but the 16-bit envelope length silently truncates above 64 KiB. v4 references the map by hash from the cluster envelope; bigtent loads it at open time and synthesises the `alias:from` edges that the writer strips.
- **Binary `Identifier` form for `.gri` MD5 keys.** Goatrodeo now hashes the binary `Identifier` layout (kind nibble + raw hash bytes or UTF-8) rather than the canonical text. Bigtent's `md5hash_str` mirrors that encoding; v1 clusters using `md5(utf8)` keys still resolve through a canonical-string fallback.
- **Alias-identifier lookups preserved across the format change.** Alternate-form identifiers (md5, sha1, sha256, sha512, alternate-form gitoids) are no longer stand-alone Items in the v4 `.grd`; they live only as entries in the `.gra` sidecar. `item_for_identifier` falls back to the sidecar on miss and synthesises the same pointer Item v1 stored on disk (one `alias:to → canonical` edge, no body), so `/item/<alias>`, `/aa/<alias>`, `/flatten/<alias>`, `/north/<alias>`, and `/has/<alias>` all behave the same way they did against v1 clusters.

The wire-format version dispatches at runtime (v < 2 → legacy `Item` codec; v ≥ 2 → streamed `WireItem` + resolution). v1 fixtures (`test_data/cluster_a..d`) keep passing without rebuild.

## Test plan

- [x] All 37 lib tests pass against a freshly-built v4 cluster.
- [x] v1 cluster fixtures still resolve (canonical-string MD5 fallback).
- [x] Goatrodeo's own 1,329-test suite stays green against the new readers (`test_purls_and_merge` round-trips a v4 cluster through bigtent).
- [x] Manual round-trip QA against `HP1973-Source.zip`-rooted clusters:
    - **Canonical** identifier (`gitoid:blob:sha256:49224bf9…`): `/item`, `/aa`, `/flatten` are byte-identical across v1-baseline (origin/main bigtent + goatrodeo) and v4 (PR HEAD bigtent + goatrodeo). `/node_count` differs by design (233 → 36 from alias collapse).
    - **Alias** identifier (`gitoid:blob:sha1:82e1e0bb…`, `md5:ff9074…`): `/item/<alias>` is byte-identical between v1 and v4 (returns the same pointer Item with `alias:to → canonical`). `/aa/<alias>` matches modulo the per-build random `tag:from` gitoid (an artefact of two independent builds, not a behaviour difference).
    - **Unknown** identifier: 404 in both versions.

Marked draft until goatrodeo#264 lands; merging this side first would expect v4 clusters that don't exist yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)