### PR TITLE
Upgrade actions/checkout to v5 for Node.js 24 Compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check Cargo Version Matches Tag
         uses: spice-labs-inc/action-check-version@main
@@ -40,7 +40,7 @@ jobs:
           platforms: ${{ env.PLATFORMS }}
 
       - name: Checkout with LFS
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           lfs: true
 


### PR DESCRIPTION
### Summary

Updates both CI workflows to resolve Node.js 20 deprecation warnings on GitHub
Actions runners. `actions/checkout` has been updated to v5 in `build.yml` and
across both jobs in `publish.yml`, ahead of the June 16th enforcement date.

### Changes

- Updated `actions/checkout` from `@v4` to `@v5` in `build.yml`
- Updated `actions/checkout` from `@v4` to `@v5` in the `check-version` job
  in `publish.yml`
- Updated `actions/checkout` from `@v4` to `@v5` in the `push_to_dockerhub`
  job in `publish.yml`

### Tests

- Push to any branch and confirm the `build` job completes successfully,
  including Cargo build and tests
- Push a semver tag (e.g. `v1.2.3`) and confirm the `check-version` job passes
  the Cargo.toml version check, followed by the `push_to_dockerhub` job
  completing successfully, including multi-platform Docker build and push to
  Docker Hub, SBOM generation, and ADG upload
- Verify the published image is accessible at `spicelabs/bigtent` on Docker Hub
  with the correct semver tags

### Impact

No change to build, test, or publish behaviour. Both runners were already
correctly pinned to `ubuntu-24.04`. All other actions
(`docker/setup-qemu-action@v3`, `docker/setup-buildx-action@v3`,
`docker/login-action@v3`, `docker/metadata-action@v5`,
`docker/build-push-action@v6`, `dtolnay/rust-toolchain@stable`,
`Swatinem/rust-cache@v2`, `spice-labs-inc/action-spice-labs-surveyor@v5`)
required no changes.

### Ticket

- https://github.com/spice-labs-inc/internal-docs/issues/509